### PR TITLE
Exclude building tar.xz on arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         type: [tar.xz, qcow2]
         arch: [amd64, arm64]
+        exclude:
+          - type: tar.xz
+            arch: arm64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
There seem to be some package issues with the ARM64 build on Windows. For now, I’m going to exclude this build since it’s not needed at the moment.

Related to: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/47