### PR TITLE
CI: Only save cache on main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,8 +40,8 @@ jobs:
           buildkitd-flags: "--allow-insecure-entitlement security.insecure"
           platforms: linux/${{ matrix.arch }}
 
-      - name: Set up Docker layer cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Restore Docker layer cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/cache
           key: ${{ runner.arch }}-buildx-${{ matrix.type }}-${{ github.sha }}
@@ -62,3 +62,10 @@ jobs:
         with:
           name: distro-${{ matrix.type }}-${{ matrix.arch }}
           path: distro.${{ matrix.type }}
+
+      - name: Save Docker layer cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/cache
+          key: ${{ runner.arch }}-buildx-${{ matrix.type }}-${{ github.sha }}


### PR DESCRIPTION
Our caches are rather big (nearly all of the total quota).  Unless the cache was built from the default branch, it can only be used from the same branch as the run that pushed it.  This means that we end up pushing lots of cache that can never be reused, causing the actually useful ones (i.e. the caches from the default branch) to be evicted due to space.

Fix this by using explicit cache save and restore, and then limiting the save to only apply on the main branch.

This depends on #5 because of merge conflicts.