### PR TITLE
CI: Add workflow to upload release assets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,10 @@
 name: Build
 on:
   push:
+    branches: [ '**' ]
+    tags-ignore: [ 'v*', 'test-v*' ]
   pull_request:
+  workflow_call:
   workflow_dispatch:
 permissions:
   contents: read
@@ -58,7 +61,7 @@ jobs:
           make GOARCH=${{ matrix.arch }} distro.${{ matrix.type }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: distro-${{ matrix.type }}-${{ matrix.arch }}
           path: distro.${{ matrix.type }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Release Artifacts
+on:
+  push:
+    tags: [ 'v*', 'test-v*' ]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: Build Artifacts
+    uses: ./.github/workflows/build.yaml
+  upload:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create releases.
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        pattern: distro-*
+    - name: Extract artifacts
+      run: |
+        set -o errexit -o nounset -o xtrace
+        for arch in amd64 arm64; do
+          mv distro-qcow2-${arch}/distro.qcow2 distro.${GITHUB_REF_NAME}.${arch}.qcow2
+          rmdir distro-qcow2-${arch}/
+          mv distro-tar.xz-${arch}/distro.tar.xz distro.${GITHUB_REF_NAME}.${arch}.tar.xz
+          rmdir distro-tar.xz-${arch}/
+        done
+        for f in distro.*.{qcow2,tar.xz}; do
+          sha256sum "$f" > "$f.sha256"
+        done
+    - name: Create release
+      run: >-
+        gh release create
+        --title "${GITHUB_REF_NAME#test-}"
+        --draft
+        --generate-notes
+        --verify-tag
+        --repo ${{ github.repository }}
+        "${GITHUB_REF_NAME}"
+        distro.*.{qcow2,tar.xz}{,.sha256}
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ architecture as used by the [go toolchain].  This requires your docker daemon to
 be able to emulate that architecture.
 
 [go toochain]: https://go.dev/doc/install/source#environment
+
+## Release Process
+
+Push a tag of the form `v*` (or `test-v*` for testing if testing in a fork is
+not possible), and the [release workflow](.github/workflows/release.yaml) will
+create a draft release with the artifacts.


### PR DESCRIPTION
On creating a tag of the form `v*` (or `test-v*`), the workflow will create a draft release with the artifacts.  This what [rancher-sandbox/rancher-desktop-wsl-distro](https://github.com/rancher-sandbox/rancher-desktop-wsl-distro) does.  Fixes #8.

The README has been updated with instructions, because looking up what each repository needs is annoying.

Sample run: https://github.com/mook-as/rancher-desktop-opensuse/actions/runs/21844156978/job/63037193353
Sample release is draft, and therefore not visible publicly; it looks something like:

```
$ gh release view --repo mook-as/rancher-desktop-opensuse v0.0.0.20260209225553
v0.0.0.20260209225553
Draft • github-actions[bot] created this about 21 minutes ago

  Full Changelog: https://github.com/mook-as/rancher-desktop-opensuse/commits/v0.0.0.20260209225553                   


Assets
NAME                                              DIGEST                                                                   SIZE      
distro.v0.0.0.20260209225553.amd64.qcow2          sha256:c5c858c32ce27d92fbd36a368b03742d95384bc3c0fe44904e4103be845b44d5  441.44 MiB
distro.v0.0.0.20260209225553.amd64.qcow2.sha256   sha256:3e08ffe0d9f929816564c456b6369e598b7f0057c80b2eeab318be636ebf5742  107 B
distro.v0.0.0.20260209225553.amd64.tar.xz         sha256:51602f966660593571a73c2d5cb7c8858c90b97c6523cfbc5c667b8ac9f580d2  204.79 MiB
distro.v0.0.0.20260209225553.amd64.tar.xz.sha256  sha256:979f77fc6e34b3120ad8c4f4aa7524c835935293378cb80590cf2518d2fcd340  108 B
distro.v0.0.0.20260209225553.arm64.qcow2          sha256:d60270804dba3d39253e2b0a5d89ec444a9fb4f1a4a9ba707a9dac47372de8c2  393.70 MiB
distro.v0.0.0.20260209225553.arm64.qcow2.sha256   sha256:294fefc474a20c333167bbaffee9cb3ec257b42f0da6083e431c9db9be1c13e5  107 B
distro.v0.0.0.20260209225553.arm64.tar.xz         sha256:967f4edc11086716af28c30d39f09a8ae95c9c2e7f6a8f0723c3e431a5f3f806  171.37 MiB
distro.v0.0.0.20260209225553.arm64.tar.xz.sha256  sha256:0364f8e256742f7454663d7a04ec7bf3b0da050e5687c24dd26c6fe4ef26ae4a  108 B

View on GitHub: https://github.com/mook-as/rancher-desktop-opensuse/releases/tag/untagged-0426605cf7b86be0c26f
```