### PR TITLE
Shrink distro artifacts via external xz and build-time cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 distro.tar.xz
 distro.qcow2.xz
+distro.raw.xz

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 distro.tar.xz
-distro.qcow2
+distro.qcow2.xz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,16 @@ jobs:
         - type: tar.xz
           arch: arm64
           runs-on: ubuntu-24.04-arm
-        - type: qcow2
+        - type: raw.xz
           arch: amd64
           runs-on: ubuntu-latest
-        - type: qcow2
+        - type: raw.xz
+          arch: arm64
+          runs-on: ubuntu-24.04-arm
+        - type: qcow2.xz
+          arch: amd64
+          runs-on: ubuntu-latest
+        - type: qcow2.xz
           arch: arm64
           runs-on: ubuntu-24.04-arm
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,12 +23,14 @@ jobs:
       run: |
         set -o errexit -o nounset -o xtrace
         for arch in amd64 arm64; do
-          mv distro-qcow2-${arch}/distro.qcow2 distro.${GITHUB_REF_NAME}.${arch}.qcow2
-          rmdir distro-qcow2-${arch}/
+          mv distro-raw.xz-${arch}/distro.raw.xz distro.${GITHUB_REF_NAME}.${arch}.raw.xz
+          rmdir distro-raw.xz-${arch}/
+          mv distro-qcow2.xz-${arch}/distro.qcow2.xz distro.${GITHUB_REF_NAME}.${arch}.qcow2.xz
+          rmdir distro-qcow2.xz-${arch}/
           mv distro-tar.xz-${arch}/distro.tar.xz distro.${GITHUB_REF_NAME}.${arch}.tar.xz
           rmdir distro-tar.xz-${arch}/
         done
-        for f in distro.*.{qcow2,tar.xz}; do
+        for f in distro.*.{raw.xz,qcow2.xz,tar.xz}; do
           sha256sum "$f" > "$f.sha256"
         done
     - name: Create release
@@ -40,6 +42,6 @@ jobs:
         --verify-tag
         --repo ${{ github.repository }}
         "${GITHUB_REF_NAME}"
-        distro.*.{qcow2,tar.xz}{,.sha256}
+        distro.*.{raw.xz,qcow2.xz,tar.xz}{,.sha256}
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /root/build/
 *.qcow2.xz
+*.raw.xz
 *.tar.xz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /root/build/
-*.qcow2
+*.qcow2.xz
 *.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,14 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 FROM registry.opensuse.org/opensuse/bci/kiwi:10 AS builder
 ARG type=qcow2.xz
 ARG NERDCTL_VERSION
+# The BCI kiwi image ships /etc/kiwi.yml with mapper and runtime_checks
+# settings required for building inside Docker. Append xz -0 so kiwi
+# does not waste time on compression we discard and recompress at
+# xz -9 --extreme in Makefile.docker. Using --config would replace the
+# existing file and lose the mapper setting, breaking loop devices.
 RUN --mount=type=cache,target=/var/cache/zypp \
-    zypper --non-interactive install parted
+    zypper --non-interactive install parted && \
+    echo -e '\nxz:\n  - options: '\''-0'\''' >> /etc/kiwi.yml
 WORKDIR /build
 COPY . /description
 COPY --from=gobuild /go/bin/* /description/root/usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go build -ldflags '-s -w' -o /go/bin/rd-init .
 
 FROM registry.opensuse.org/opensuse/bci/kiwi:10 AS builder
-ARG type=qcow2
+ARG type=qcow2.xz
 ARG NERDCTL_VERSION
 RUN --mount=type=cache,target=/var/cache/zypp \
     zypper --non-interactive install parted
@@ -32,4 +32,4 @@ RUN --security=insecure \
     make -C /description -f Makefile.docker TYPE=${type}
 
 FROM scratch
-COPY --from=builder /build/*.qcow2 /build/*.tar.xz /
+COPY --from=builder /build/*.raw.xz /build/*.qcow2.xz /build/*.tar.xz /

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ include root/build/versions.env
 GO ?= $(or $(shell which go.exe),$(shell which go))
 GOARCH ?= $(shell $(GO) env GOARCH)
 GOOS ?= $(shell $(GO) env GOOS)
-TYPE ?= $(if $(filter windows,$(GOOS)),tar.xz,qcow2)
+TYPE ?= $(if $(filter windows,$(GOOS)),tar.xz,raw.xz)
 
-# Default target is either `distro.qcow2` or `distro.tar.xz`
+# Default target is either `distro.raw.xz` or `distro.tar.xz`
 distro.$(TYPE):
 
 DOWNLOADS += root/build/nerdctl-$(NERDCTL_VERSION).tgz
@@ -35,4 +35,4 @@ distro.%: $(DOWNLOADS) $(IMAGE_FILES)
 		--platform=linux/$(GOARCH) --output=. --build-arg=type=$* .
 
 clean:
-	rm -f distro.tar.xz distro.qcow2 $(DOWNLOADS)
+	rm -f distro.tar.xz distro.qcow2.xz $(DOWNLOADS)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -33,18 +33,20 @@ rancher-desktop-distro.%.tar.xz: config.kiwi config.sh ${INPUTS}
 #            xz-compressed for storage/transfer.
 /build/distro.raw.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.raw
 	./clean-rootfs.sh $<
-	xz -9e -T0 -c $< > $@
+	xz -9 --extreme --stdout $< > $@
 
-/build/distro.qcow2.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.raw
+/build/distro.qcow2: /build/rancher-desktop-distro.$(ARCH)-0.100.0.raw
 	./clean-rootfs.sh $<
-	qemu-img convert -c -f raw $< -O qcow2 -o compression_type=zstd,compat=1.1 $(@:.xz=)
-	xz -9e -T0 -c $(@:.xz=) > $@
-	rm $(@:.xz=)
+	qemu-img convert -c -f raw $< -O qcow2 -o compression_type=zstd,compat=1.1 $@
+
+/build/distro.qcow2.xz: /build/distro.qcow2
+	xz -9 --extreme --stdout $< > $@
 
 # Recompress the tarball kiwi leaves behind. Kiwi runs xz in threaded
 # mode with 24 MiB blocks, which loses a meaningful chunk of ratio to
-# block boundaries; a single xz -9e pass is ~14% smaller.
+# block boundaries; a single xz -9 --extreme pass is ~14% smaller.
 /build/distro.tar.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.tar.xz
-	xz -dc $< | xz -9e -T0 > $@
+	xz --decompress --stdout $< | xz -9 --extreme > $@
 
+.INTERMEDIATE: /build/distro.qcow2
 .DELETE_ON_ERROR: # Avoid half-downloaded files

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,7 +2,7 @@
 
 include root/build/versions.env
 
-TYPE ?= qcow2
+TYPE ?= raw.xz
 ARCH ?= $(shell uname -m)
 
 /build/distro.${TYPE}:
@@ -12,7 +12,7 @@ GO_ARCH := $(GO_ARCH:aarch64=arm64)
 
 INPUTS += root/build/nerdctl-$(NERDCTL_VERSION).tgz
 
-rancher-desktop-distro.%.qcow2: config.kiwi config.sh ${INPUTS}
+rancher-desktop-distro.%.raw: config.kiwi config.sh ${INPUTS}
 	kiwi --debug --profile=lima system build \
 		--description /description --target-dir /build
 
@@ -20,10 +20,31 @@ rancher-desktop-distro.%.tar.xz: config.kiwi config.sh ${INPUTS}
 	kiwi --debug --profile=wsl system build \
 		--description /description --target-dir /build
 
-/build/distro.qcow2: /build/rancher-desktop-distro.$(ARCH)-0.100.0.qcow2
-	mv $< $@
+# Post-kiwi cleanup, then produce the requested output format.
+#
+# clean-rootfs.sh loop-mounts the raw disk, removes grub2 build tools
+# and other build-time artifacts, then fstrim's the filesystem so freed
+# blocks become holes. It runs here rather than in pre_disk_sync.sh
+# because kiwi re-invokes grub2-mkconfig on the mounted disk after that
+# hook.
+#
+# raw.xz  — for macOS/VZ: qemu and VZ both consume raw directly.
+# qcow2.xz — for Linux/qemu: internally zstd-compressed, then
+#            xz-compressed for storage/transfer.
+/build/distro.raw.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.raw
+	./clean-rootfs.sh $<
+	xz -9e -T0 -c $< > $@
 
+/build/distro.qcow2.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.raw
+	./clean-rootfs.sh $<
+	qemu-img convert -c -f raw $< -O qcow2 -o compression_type=zstd,compat=1.1 $(@:.xz=)
+	xz -9e -T0 -c $(@:.xz=) > $@
+	rm $(@:.xz=)
+
+# Recompress the tarball kiwi leaves behind. Kiwi runs xz in threaded
+# mode with 24 MiB blocks, which loses a meaningful chunk of ratio to
+# block boundaries; a single xz -9e pass is ~14% smaller.
 /build/distro.tar.xz: /build/rancher-desktop-distro.$(ARCH)-0.100.0.tar.xz
-	mv $< $@
+	xz -dc $< | xz -9e -T0 > $@
 
 .DELETE_ON_ERROR: # Avoid half-downloaded files

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Desktop.
 
 The distribution is built using `docker`:
 ```sh
-make TYPE=qcow2.xz # For Linux/darwin hosts
-make TYPE=tar.xz # For WSL hosts
+make TYPE=raw.xz   # For macOS/VZ hosts (default)
+make TYPE=qcow2.xz # For Linux/qemu hosts
+make TYPE=tar.xz   # For WSL hosts
 ```
 
 To cross-compile for a non-native architecture, set `GOARCH` to the target

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Desktop.
 
 The distribution is built using `docker`:
 ```sh
-make TYPE=qcow2 # For Linux/darwin hosts
+make TYPE=qcow2.xz # For Linux/darwin hosts
 make TYPE=tar.xz # For WSL hosts
 ```
 

--- a/clean-rootfs.sh
+++ b/clean-rootfs.sh
@@ -22,7 +22,7 @@ for p in /dev/mapper/"$(basename "$LOOP")"p*; do
     ROOT=$p
     break
 done
-test -n "$ROOT"
+: ${ROOT:?Failed to find ext4 partition in $RAW}
 
 MNT=$(mktemp -d)
 mount "$ROOT" "$MNT"

--- a/clean-rootfs.sh
+++ b/clean-rootfs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Post-kiwi cleanup of the root filesystem inside a raw disk image.
+# Called from Makefile.docker after kiwi has finished writing the raw
+# disk (including grub2-mkconfig). Shared by the raw.xz and qcow2.xz
+# build targets.
+#
+# Usage: ./clean-rootfs.sh /path/to/raw-disk.img
+
+set -o errexit
+
+RAW=$1
+
+LOOP=$(losetup --find --show "$RAW")
+kpartx -as "$LOOP"
+
+# Find the ext4 root partition. The layout differs between amd64
+# (p1=bios-boot, p2=EFI, p3=root) and arm64 (p1=EFI, p2=root).
+ROOT=
+for p in /dev/mapper/"$(basename "$LOOP")"p*; do
+    [ "$(blkid -o value -s TYPE "$p" 2>/dev/null)" = ext4 ] || continue
+    ROOT=$p
+    break
+done
+test -n "$ROOT"
+
+MNT=$(mktemp -d)
+mount "$ROOT" "$MNT"
+
+# grub2 build/install tools. The EFI bootloader and runtime grub modules
+# in /boot/grub2 are already in place; these commands are not invoked
+# again. Keep grub2-editenv for grubenv management.
+find "$MNT/usr/bin" "$MNT/usr/sbin" -maxdepth 1 -name 'grub2-*' \
+    ! -name 'grub2-editenv' -delete
+
+# Config files only read by grub2-mkconfig, which we just removed.
+rm -rf "$MNT/etc/grub.d" "$MNT/etc/default/grub"
+
+# /usr/share/grub2/<arch>-efi is the factory copy of the grub modules
+# that grub2-install replicated into /boot/grub2/<arch>-efi.
+rm -rf "$MNT/usr/share/grub2"/*-efi
+rm -f  "$MNT/usr/share/grub2"/*.pf2
+rm -rf "$MNT/usr/share/grub2/grub-mkconfig_lib" "$MNT/usr/share/grub2/themes"
+
+sync
+
+# Discard freed blocks so they become holes in the backing raw file.
+# qemu-img and xz both benefit from this.
+fstrim "$MNT"
+
+umount "$MNT"
+rmdir "$MNT"
+kpartx -d "$LOOP"
+losetup --detach "$LOOP"

--- a/config.kiwi
+++ b/config.kiwi
@@ -101,6 +101,11 @@
     <package name="systemd-resolved" />
     <package name="grub2-x86_64-efi" arch="x86_64" />
   </packages>
+  <packages type="delete" profiles="lima">
+    <!-- Pulled in by cni-plugin-flannel but we use k3s's embedded flannel
+         daemon, so the standalone flanneld binary is dead weight. -->
+    <package name="flannel" />
+  </packages>
   <users>
     <user pwdformat="plain" password="suse" home="/root" name="root" groups="root" />
   </users>

--- a/pre_disk_sync.sh
+++ b/pre_disk_sync.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Kiwi runs this hook chrooted in the build root after create_initrd and
+# before the filesystem is synced to the raw disk. All bind mounts from
+# the prepare phase are already gone, so anything we rm here actually
+# comes out of the final image.
+#
+# grub2-mkconfig and the rest of the grub2 build tools can NOT be
+# touched here — kiwi re-invokes grub2-mkconfig on the mounted disk
+# after this hook. That cleanup happens in Makefile.docker instead,
+# after kiwi has finished with the raw disk.
+
+set -o errexit
+
+# Dracut is the initramfs generator. Kiwi needed it up to the create_initrd
+# step right before this hook runs; we don't need it at runtime.
+rpm -e --nodeps dracut
+rm -rf /usr/lib/dracut /etc/dracut.conf.d
+
+# Kernel debug artifacts — only useful for crash analysis. The live kernel
+# at /boot/Image (a symlink into this directory) is untouched.
+rm -f /usr/lib/modules/*/vmlinux.xz
+rm -f /usr/lib/modules/*/System.map
+
+# Leftover build-time state that survived into image-root.
+rm -rf /var/cache/zypp/* /var/cache/kiwi/* /var/cache/zypper/*
+rm -rf /var/log/*
+rm -rf /tmp/* /var/tmp/*
+rm -f  /var/lib/rpm/__db.*
+rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/*


### PR DESCRIPTION
<!-- PR title: Shrink distro artifacts via external xz and build-time cleanup -->

Switch the lima artifact from a single zstd-compressed qcow2 to two formats (xz-compressed raw disk + xz-compressed qcow2), drop build-time-only content, and recompress the WSL tarball at `xz -9e`.

## Three output formats

All three artifacts are now xz-compressed for storage and transfer:

**`distro.raw.xz`** — xz-compressed raw disk for macOS/VZ. Both qemu and VZ consume raw directly, so there is no `qemu-img convert` step during install. Smallest download / `go:embed` blob (~201 MiB arm64).

**`distro.qcow2.xz`** — internally zstd-compressed qcow2, then xz-compressed. For Linux/qemu: decompress the xz layer once at install time, then qemu reads clusters on the fly from the zstd layer. ~199 MiB compressed; ~334 MiB decompressed on disk.

**`distro.tar.xz`** — WSL tarball (unchanged format, recompressed at `-9e`, ~142 MiB arm64).

## Compression

`qemu-img`'s internal zstd runs at a low level. A single `xz -9e` pass over the raw disk produces a much smaller artifact for distribution and `go:embed`. xz handles the ~400 MiB of zero holes in the raw file efficiently. Kiwi's own tar.xz output runs a threaded xz at default level and loses ~14% to block boundaries; recompress it at `-9e` as well.

The qcow2 keeps internal zstd compression for qemu's on-the-fly cluster decompression, then gets an external `xz -9e` pass for smaller downloads and storage. qemu cannot read the `.xz` directly — the consumer must decompress before use.

`xz -9e` takes about 2.5 minutes per artifact on a release build, which runs only in CI. Decompression is ~2 seconds.

## Content cleanup

**`config.kiwi`** — drop the standalone flanneld binary via `<packages type="delete">`. `cni-plugin-flannel` pulls it in, but k3s ships flannel embedded and nothing uses the standalone daemon.

**`pre_disk_sync.sh`** (new kiwi hook) — `rpm -e --nodeps dracut`, then clean the dracut helper dirs, kernel debug files (`vmlinux.xz`, `System.map`), and the usual transient state (`/var/cache`, `/var/log`, `/tmp`, `/var/tmp`, `/var/lib/rpm/__db.*`, the orphan `/usr/share/{doc,man,info}` dirs that `rpm-excludedocs` leaves empty). Both `<packages type="delete">` and `type="uninstall">` run before `create_initrd` in kiwi's lifecycle, so neither can drop dracut; `pre_disk_sync.sh` runs right after the initrd is built.

**`clean-rootfs.sh`** (shared by both lima targets) — loop-mounts the raw disk after kiwi finishes, finds the ext4 partition (the layout differs between amd64 and arm64), and drops the grub2 build tools (keeping `grub2-editenv` for grubenv management), `/etc/grub.d`, `/etc/default/grub`, the duplicate `/usr/share/grub2/*-efi` subtree, the grub2 fonts, and `grub-mkconfig_lib`. `fstrim`'s the filesystem so the freed blocks become holes in the backing raw file. Cannot live in `pre_disk_sync.sh` because kiwi re-invokes `grub2-mkconfig` after that hook.

## Install-time sparseness (raw.xz)

The raw file is 1.32 GiB virtual size with about 400 MiB of zero holes. `xz -d` preserves sparseness automatically on any POSIX filesystem that supports holes, so a plain `xz -d file.raw.xz` lands at ~971 MiB on disk (Linux and macOS both). A Go extractor using 4 KiB zero-block detection with `Seek()` can reduce this to the ~934 MiB theoretical floor.

Lima shells out to the `xz` binary during image import, so macOS users currently need `brew install xz`. That dependency goes away once `rdd` embeds the image and decompresses via `github.com/ulikunitz/xz` in-process.

## Release workflow

`release.yaml` is updated to extract and upload all three artifact types (`distro.raw.xz`, `distro.qcow2.xz`, `distro.tar.xz`) with sha256 checksums.

## Functional parity

The artifacts remain functionally identical: only packages exclusive to the lima profile get cut, plus transient build state that nothing references at runtime.

## Size progression (arm64)

| artifact            | main     | this branch |
| ------------------- | -------- | ----------- |
| lima raw             | —        | **201 MiB** `distro.raw.xz` |
| lima qcow2           | ~376 MiB `distro.qcow2` (old zstd) | **199 MiB** `distro.qcow2.xz` (−47%) |
| wsl tarball          |  165 MiB `distro.tar.xz` | **142 MiB** `distro.tar.xz` (−14%) |
