### PR TITLE
Fix proxy always enabled even without allowed-images config

### DIFF
--- a/root/usr/local/lib/systemd/system/containerd.service.d/allowed-images.conf
+++ b/root/usr/local/lib/systemd/system/containerd.service.d/allowed-images.conf
@@ -4,7 +4,7 @@
 EnvironmentFile=-/etc/sysconfig/allowed-images.env
 ExecStartPre=/bin/sh -c '\
     set -x ; \
-    if $ALLOWED_IMAGES ; then \
+    if [ -f /usr/local/openresty/nginx/conf/allowed-images.conf ] ; then \
         echo HTTPS_PROXY=http://127.0.0.1:3128 > /etc/sysconfig/allowed-images.env ; \
     else \
         rm -f /etc/sysconfig/allowed-images.env ; \

--- a/root/usr/local/lib/systemd/system/docker.service.d/allowed-images.conf
+++ b/root/usr/local/lib/systemd/system/docker.service.d/allowed-images.conf
@@ -4,7 +4,7 @@
 EnvironmentFile=-/etc/sysconfig/allowed-images.env
 ExecStartPre=/bin/sh -c '\
     set -x ; \
-    if $ALLOWED_IMAGES ; then \
+    if [ -f /usr/local/openresty/nginx/conf/allowed-images.conf ] ; then \
         echo HTTPS_PROXY=http://127.0.0.1:3128 > /etc/sysconfig/allowed-images.env ; \
     else \
         rm -f /etc/sysconfig/allowed-images.env ; \


### PR DESCRIPTION
The ExecStartPre condition `if $ALLOWED_IMAGES` expands to bare `if` when the variable is unset, which succeeds unconditionally. Docker and containerd then start with `HTTPS_PROXY=http://127.0.0.1:3128` even when OpenResty is not installed, breaking all image pulls.

Test for the config file the comment already describes instead.