### PR TITLE
Gate docker.socket and tee unit output to the console

### DIFF
--- a/config.kiwi
+++ b/config.kiwi
@@ -19,7 +19,7 @@
   </preferences>
   <preferences profiles="lima">
     <type image="oem" format="qcow2" filesystem="ext4" fsmountoptions="x-systemd.growfs"
-      firmware="efi" kernelcmdline="console=hvc0 console=tty0 console=ttyS0,115200">
+      firmware="efi" kernelcmdline="console=tty0 console=ttyS0,115200 console=hvc0">
       <oemconfig>
         <!--
           Disable Kiwi's built-in partition resizing; that is very generic and

--- a/config.sh
+++ b/config.sh
@@ -102,6 +102,7 @@ if [[ ${kiwi_profiles:-} =~ lima ]]; then
 
     systemctl enable lima-init.service
     systemctl enable rd-init.service
+    systemctl enable journal-to-console.service
     # Disable network namespace related functionality (WSL only)
     rm -f /usr/local/lib/systemd/system/*/network-namespace.conf
     # Remove the docker config that is only used on Windows

--- a/root/usr/local/lib/systemd/system/docker.socket.d/target.conf
+++ b/root/usr/local/lib/systemd/system/docker.socket.d/target.conf
@@ -1,0 +1,7 @@
+# Override docker.socket to install to rancher-desktop.target
+[Install]
+WantedBy=
+WantedBy=rancher-desktop.target
+
+[Unit]
+StopPropagatedFrom=rancher-desktop.target

--- a/root/usr/local/lib/systemd/system/journal-to-console.service
+++ b/root/usr/local/lib/systemd/system/journal-to-console.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Mirror the journal to the console for boot diagnostics
-After=systemd-journald.service
+DefaultDependencies=no
 Requires=systemd-journald.service
+After=systemd-journald.service
+Before=sysinit.target shutdown.target
+Conflicts=shutdown.target
 
 [Service]
 Type=simple
@@ -13,4 +16,4 @@ Restart=always
 RestartSec=1
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/root/usr/local/lib/systemd/system/journal-to-console.service
+++ b/root/usr/local/lib/systemd/system/journal-to-console.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mirror the journal to the console for boot diagnostics
+After=systemd-journald.service
+Requires=systemd-journald.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/journalctl --boot --follow --no-hostname --no-pager --output=short
+StandardOutput=tty
+StandardError=journal
+TTYPath=/dev/console
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/root/usr/local/lib/systemd/system/lima-init.service
+++ b/root/usr/local/lib/systemd/system/lima-init.service
@@ -15,7 +15,6 @@ EnvironmentFile=/mnt/lima-cidata/lima.env
 ExecStart=/mnt/lima-cidata/boot.sh
 RemainAfterExit=yes
 TimeoutSec=0
-StandardOutput=journal+console
 
 [Install]
 WantedBy=multi-user.target

--- a/root/usr/local/lib/systemd/system/rd-init.service
+++ b/root/usr/local/lib/systemd/system/rd-init.service
@@ -15,7 +15,6 @@ EnvironmentFile=/mnt/lima-cidata/lima.env
 ExecStart=/usr/local/bin/rd-init
 RemainAfterExit=yes
 TimeoutSec=0
-StandardOutput=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Two small additions motivated by a rancher-desktop-daemon CI failure where `systemctl is-active docker` returned `failed` instead of `inactive` after switching container engine to containerd.

### docker.socket.d/target.conf

`docker.service` already overrides its `[Install]` to `WantedBy=rancher-desktop.target`. `docker.socket` did not, so it inherited the upstream `WantedBy=sockets.target` and started listening at boot, before Lima's provision script had a chance to set `CONTAINER_ENGINE=containerd`. Socket activation then launched `dockerd` with stale env, and the subsequent `Conflicts=` stop from `containerd.service` left `docker.service` in `failed`.

The new drop-in mirrors `docker.service.d/target.conf`, so the existing `systemctl disable docker.socket` in the provision script now keeps the socket out of `rancher-desktop.target.wants/` in containerd mode, and nothing can activate `dockerd` at all.

`buildkitd.socket` already installs into `rancher-desktop.target` directly, and upstream containerd ships no `.socket` unit.

### journal-to-console.service

`config.kiwi` already tees kernel and early-systemd output to the serial consoles Lima captures (commit 00c5843), but individual services default to `StandardOutput=journal`, so unit-level output never reaches Lima's log files. This is why the original failure left no evidence there.

The new service runs `journalctl --boot --follow` with its output connected to `/dev/console`, so every journal entry is mirrored to whichever serial console the current backend has available (the kernel picks `/dev/console` per-backend, no hardcoded device). `journalctl --boot` catches everything from the current boot up to the point the service starts, so the early window is not lost.

A dedicated follower keeps the forwarding out of journald itself. `ForwardToConsole=yes` (and `StandardOutput=journal+console`) both perform the console writes inside the journald process, so a slow or blocked console stalls journald and cascades into every service logging synchronously to it. With this service, a blocked console stalls only the follower, and the journal itself keeps moving.

Future regressions in any service — docker, containerd, k3s, buildkitd, cloud-init re-runs — will be diagnosable from Lima's captured logs alone.