### PR TITLE
lima-init.service: Run in network namespace

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -88,6 +88,7 @@ chmod 0755 /usr/local/libexec/udhcpc/*.script
 # Enable services
 #--------------------------------------
 systemctl enable sshd
+systemctl enable lima-init.service
 
 #======================================
 # Linux/darwin-specific fixes
@@ -100,7 +101,6 @@ if [[ ${kiwi_profiles:-} =~ lima ]]; then
     systemctl enable systemd-networkd
     systemctl enable systemd-resolved
 
-    systemctl enable lima-init.service
     systemctl enable rd-init.service
     systemctl enable journal-to-console.service
     # Disable network namespace related functionality (WSL only)
@@ -113,6 +113,10 @@ fi
 # WSL-specific fixes
 #--------------------------------------
 if [[ ${kiwi_profiles:-} =~ wsl ]]; then
+    # No rd-init.service or ci-data mount on WSL
+    rm -f /usr/local/lib/systemd/system/lima-init.service.d/requires-cidata.conf
+    rm -f /usr/local/lib/systemd/system/lima-init.service.d/requires-rd-init.conf
+
     # Enable network namespace
     systemctl enable network-setup
     systemctl enable rancher-desktop-guest-agent.service

--- a/root/usr/local/lib/systemd/system/lima-init.service
+++ b/root/usr/local/lib/systemd/system/lima-init.service
@@ -1,10 +1,8 @@
 [Unit]
 Description=Minimal cloud-init for Rancher Desktop
-ConditionVirtualization=vm
-Wants=rd-init.service ssh-keygen.service sshd.service
-After=rd-init.service systemd-networkd-wait-online.service
+Wants=ssh-keygen.service sshd.service
+After=systemd-networkd-wait-online.service
 After=network.service NetworkManager.service NetworkManager-wait-online.service
-RequiresMountsFor=/mnt/lima-cidata
 Before=network-online.target sshd-keygen.service sshd.service shutdown.target
 Conflicts=shutdown.target
 

--- a/root/usr/local/lib/systemd/system/lima-init.service.d/network-namespace.conf
+++ b/root/usr/local/lib/systemd/system/lima-init.service.d/network-namespace.conf
@@ -1,0 +1,7 @@
+[Unit]
+Requires=network-namespace.service network-setup.service
+After=network-setup.service
+
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/wsl-exec /mnt/lima-cidata/boot.sh

--- a/root/usr/local/lib/systemd/system/lima-init.service.d/requires-cidata.conf
+++ b/root/usr/local/lib/systemd/system/lima-init.service.d/requires-cidata.conf
@@ -1,0 +1,5 @@
+# On non-WSL platforms, we require /mnt/lima-cidata (for lima.env) before
+# running lima-init.service
+
+[Unit]
+RequiresMountsFor=/mnt/lima-cidata

--- a/root/usr/local/lib/systemd/system/lima-init.service.d/requires-rd-init.conf
+++ b/root/usr/local/lib/systemd/system/lima-init.service.d/requires-rd-init.conf
@@ -1,0 +1,6 @@
+# Lima-init.service requires rd-init.service, except on WSL where rd-init.service
+# is unneeded.
+
+[Unit]
+Wants=rd-init.service
+After=rd-init.service

--- a/root/usr/local/lib/systemd/system/mnt-lima-cidata.mount
+++ b/root/usr/local/lib/systemd/system/mnt-lima-cidata.mount
@@ -1,6 +1,6 @@
 [Unit]
 Description=/mnt/lima-cidata Mount Point
-ConditionVirtualization=vm
+ConditionVirtualization=!wsl
 
 [Mount]
 Where=/mnt/lima-cidata

--- a/root/usr/local/lib/systemd/system/rd-init.service
+++ b/root/usr/local/lib/systemd/system/rd-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Minimal cloud-init for Rancher Desktop (pre-networking)
-ConditionVirtualization=vm
+ConditionVirtualization=!wsl
 Wants=network-pre.target
 After=systemd-remount-fs.service
 Requires=systemd-udevd.service


### PR DESCRIPTION
We did not enable lima-init on WSL; do so, so that we can run any system-supplied provisioning scripts.  Note that we expect user script to be run under `local.service` (which is currently not implemented).

Note that we do not run `rd-init.service` on WSL.

Fixes #32