### PR TITLE
Add rdd-guest socket bridge for Windows Docker socket forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ WORKDIR /rd/rd-init
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     go build -ldflags '-s -w' -o /go/bin/rd-init .
 
+WORKDIR /rd/rdd-guest
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 go build -ldflags '-s -w' -o /go/bin/rdd-guest .
+
 FROM registry.opensuse.org/opensuse/bci/kiwi:10 AS builder
 ARG type=qcow2.xz
 ARG NERDCTL_VERSION

--- a/config.sh
+++ b/config.sh
@@ -121,6 +121,7 @@ if [[ ${kiwi_profiles:-} =~ wsl ]]; then
     systemctl enable network-setup
     systemctl enable rancher-desktop-guest-agent.service
     systemctl enable wsl-proxy.service
+    systemctl enable rdd-guest.service
     # Do not manage /tmp; that is managed by WSL.
     mkdir -p /usr/local/lib/tmpfiles.d
     touch /usr/local/lib/tmpfiles.d/fs-tmp.conf

--- a/root/usr/local/lib/systemd/system/rdd-guest.service
+++ b/root/usr/local/lib/systemd/system/rdd-guest.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Rancher Desktop Guest Socket Bridge
+Documentation=https://github.com/rancher-sandbox/rancher-desktop-daemon
+ConditionVirtualization=wsl
+
+[Service]
+ExecStart=/usr/local/bin/rdd-guest
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=rancher-desktop.target

--- a/src/rdd-guest/go.mod
+++ b/src/rdd-guest/go.mod
@@ -1,0 +1,12 @@
+module github.com/rancher-sandbox/rancher-desktop-opensuse/src/rdd-guest
+
+go 1.23.0
+
+require github.com/mdlayher/vsock v1.2.1
+
+require (
+	github.com/mdlayher/socket v0.5.1 // indirect
+	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/src/rdd-guest/go.sum
+++ b/src/rdd-guest/go.sum
@@ -1,0 +1,12 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
+github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
+github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
+github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
+golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
+golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/src/rdd-guest/main.go
+++ b/src/rdd-guest/main.go
@@ -1,0 +1,133 @@
+// Package main is the rdd-guest agent that runs inside the Lima/WSL2 VM.
+// It listens on a vsock port and forwards connections to the Docker socket,
+// enabling the Windows host to reach /var/run/docker.sock via Hyper-V vsock.
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/mdlayher/vsock"
+)
+
+const (
+	vsockPort      = 6660
+	dockerSockPath = "/var/run/docker.sock"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	l, err := vsock.Listen(vsockPort, nil)
+	if err != nil {
+		log.Fatalf("vsock listen: %v", err)
+	}
+
+	log.Printf("rdd-guest: listening on vsock port %d", vsockPort)
+
+	go func() {
+		<-ctx.Done()
+		if err := l.Close(); err != nil {
+			log.Printf("rdd-guest: close listener: %v", err)
+		}
+	}()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("rdd-guest: accept: %v", err)
+			if errors.Is(err, syscall.ECONNABORTED) {
+				continue
+			}
+			select {
+			case <-time.After(time.Second):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		go handleConn(ctx, conn)
+	}
+}
+
+// TODO: once rancher-desktop-daemon is public, replace the inlined halfCloser,
+// pipe(), and handleConn() here with a direct import of pkg/socketbridge, which
+// contains the implementations (HalfCloser interface, Pipe function).
+
+// halfCloser is a net.Conn that can independently close the write side.
+type halfCloser interface {
+	net.Conn
+	CloseWrite() error
+}
+
+// handleConn forwards bytes between the vsock connection and the Docker socket.
+// It rejects connections that do not originate from the Windows host (CID 2 /
+// vsock.Host): any process in any WSL2 distro shares the same vsock namespace
+// and could otherwise gain root Docker API access.
+func handleConn(ctx context.Context, vsockConn net.Conn) {
+	defer func() {
+		if err := vsockConn.Close(); err != nil {
+			log.Printf("rdd-guest: close vsock conn: %v", err)
+		}
+	}()
+
+	addr, ok := vsockConn.RemoteAddr().(*vsock.Addr)
+	if !ok || addr.ContextID != vsock.Host {
+		log.Printf("rdd-guest: rejected connection from %v", vsockConn.RemoteAddr())
+		return
+	}
+
+	dockerConn, err := (&net.Dialer{}).DialContext(ctx, "unix", dockerSockPath)
+	if err != nil {
+		log.Printf("rdd-guest: dial docker: %v", err)
+		return
+	}
+	defer func() {
+		if err := dockerConn.Close(); err != nil {
+			log.Printf("rdd-guest: close docker conn: %v", err)
+		}
+	}()
+
+	vsockHC, ok := vsockConn.(halfCloser)
+	if !ok {
+		log.Printf("rdd-guest: vsock conn from %v does not support CloseWrite", vsockConn.RemoteAddr())
+		return
+	}
+	dockerHC, ok := dockerConn.(halfCloser)
+	if !ok {
+		log.Printf("rdd-guest: docker conn for %v does not support CloseWrite", vsockConn.RemoteAddr())
+		return
+	}
+	pipe(vsockHC, dockerHC)
+}
+
+// pipe bidirectionally proxies between a and b until both directions are done.
+func pipe(a, b halfCloser) {
+	var wg sync.WaitGroup
+
+	forward := func(dst, src halfCloser) {
+		defer wg.Done()
+		_, err := io.Copy(dst, src)
+		if err != nil && !errors.Is(err, io.EOF) {
+			log.Printf("rdd-guest: copy: %v", err)
+		}
+		_ = dst.CloseWrite()
+	}
+
+	wg.Add(2)
+	go forward(a, b)
+	go forward(b, a)
+	wg.Wait()
+}


### PR DESCRIPTION
Build rdd-guest from rancher-desktop-daemon's cmd/rdd-guest and include it in the VM image. Add a systemd unit that starts it on WSL2 instances as part of rancher-desktop.target.

Related to: https://github.com/rancher-sandbox/rancher-desktop-daemon/pull/341
and the following issue: https://github.com/rancher-sandbox/rancher-desktop-daemon/issues/157
