### PR TITLE
Install k3s via systemd

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -89,6 +89,8 @@ find /usr/local/libexec/udhcpc -type f -name '*.script' -execdir chmod 0755 '{}'
 #--------------------------------------
 systemctl enable sshd
 systemctl enable lima-init.service
+systemctl enable k3s-install.service
+systemctl enable container-engine.target
 systemctl set-default rancher-desktop.target
 
 #======================================

--- a/config.sh
+++ b/config.sh
@@ -80,15 +80,16 @@ chmod 0750 /etc/sudoers.d
 chmod 0644 /etc/sudoers.d/*
 find /etc/systemd /usr/local/lib/systemd -type d -execdir chmod 0755 '{}' '+'
 find /etc/systemd /usr/local/lib/systemd -type f -execdir chmod 0644 '{}' '+'
-chmod 0755 /usr/local/bin/*
-chmod 0755 /usr/local/libexec/rancher-desktop/setup-namespace.sh
-chmod 0755 /usr/local/libexec/udhcpc/*.script
+find /usr/local/bin -type f -execdir chmod 0755 '{}' '+'
+find /usr/local/libexec/rancher-desktop -type f -execdir chmod 0755 '{}' '+'
+find /usr/local/libexec/udhcpc -type f -name '*.script' -execdir chmod 0755 '{}' '+'
 
 #======================================
 # Enable services
 #--------------------------------------
 systemctl enable sshd
 systemctl enable lima-init.service
+systemctl set-default rancher-desktop.target
 
 #======================================
 # Linux/darwin-specific fixes

--- a/root/usr/local/lib/systemd/system/buildkitd.service.d/environment.conf
+++ b/root/usr/local/lib/systemd/system/buildkitd.service.d/environment.conf
@@ -1,3 +1,6 @@
 # Import Rancher Desktop configuration environment variables
+[Unit]
+Requires=params.service
+After=params.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/rancher-desktop

--- a/root/usr/local/lib/systemd/system/container-engine-select.service
+++ b/root/usr/local/lib/systemd/system/container-engine-select.service
@@ -1,0 +1,12 @@
+# This service is used to select between the available container engines
+# (i.e. containerd or moby).
+[Unit]
+Description=Container Engine Selection
+Requires=params.service
+After=params.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/sysconfig/rancher-desktop
+ExecStart=/usr/local/libexec/rancher-desktop/container-engine-select.sh

--- a/root/usr/local/lib/systemd/system/container-engine.target
+++ b/root/usr/local/lib/systemd/system/container-engine.target
@@ -1,0 +1,10 @@
+# This target is reached when the configured container engine (either containerd
+# or moby) is ready.  Services that need to run after the container engine is
+# ready should be ordered after this target.
+[Unit]
+Description=Container Engine Ready
+Requires=container-engine-select.service
+After=container-engine-select.service containerd.service docker.service
+
+[Install]
+WantedBy=rancher-desktop.target

--- a/root/usr/local/lib/systemd/system/containerd.service.d/environment.conf
+++ b/root/usr/local/lib/systemd/system/containerd.service.d/environment.conf
@@ -1,3 +1,6 @@
 # Import Rancher Desktop configuration environment variables
+[Unit]
+Requires=params.service
+After=params.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/rancher-desktop

--- a/root/usr/local/lib/systemd/system/docker.service.d/environment.conf
+++ b/root/usr/local/lib/systemd/system/docker.service.d/environment.conf
@@ -1,3 +1,6 @@
 # Import Rancher Desktop configuration environment variables
+[Unit]
+Requires=params.service
+After=params.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/rancher-desktop

--- a/root/usr/local/lib/systemd/system/k3s-install.service
+++ b/root/usr/local/lib/systemd/system/k3s-install.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Kubernetes Installation
+Wants=network-online.target
+Requires=params.service
+After=network-online.target params.service
+Before=shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/sysconfig/rancher-desktop
+ExecCondition=test ${KUBERNETES_ENABLED} = true
+RemainAfterExit=yes
+ExecStart=/usr/local/libexec/rancher-desktop/k3s-install.sh
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=rancher-desktop.target

--- a/root/usr/local/lib/systemd/system/k3s-install.service.d/network-namespace.conf
+++ b/root/usr/local/lib/systemd/system/k3s-install.service.d/network-namespace.conf
@@ -1,0 +1,8 @@
+# Make k3s join the network namespace (for WSL).
+[Unit]
+Requires=network-namespace.service network-setup.service
+After=network-setup.service
+
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/wsl-exec /usr/local/libexec/rancher-desktop/k3s-install.sh

--- a/root/usr/local/lib/systemd/system/k3s.service.d/dependencies.conf
+++ b/root/usr/local/lib/systemd/system/k3s.service.d/dependencies.conf
@@ -1,0 +1,4 @@
+# Makes sure k3s.service is started after it is installed and the container engine is ready.
+[Unit]
+Requires=k3s-install.service container-engine.target
+After=k3s-install.service container-engine.target

--- a/root/usr/local/lib/systemd/system/k3s.service.d/environment.conf
+++ b/root/usr/local/lib/systemd/system/k3s.service.d/environment.conf
@@ -1,3 +1,6 @@
 # Import Rancher Desktop configuration environment variables
+[Unit]
+Requires=params.service
+After=params.service
 [Service]
 EnvironmentFile=-/etc/sysconfig/rancher-desktop

--- a/root/usr/local/lib/systemd/system/params.service
+++ b/root/usr/local/lib/systemd/system/params.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Write out Rancher Desktop Configuration
+WantsMountsFor=/mnt/lima-cidata
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/mkdir --parents /etc/sysconfig
+ExecStart=/usr/bin/sed -n "s@^PARAM_@@pw /etc/sysconfig/rancher-desktop" /mnt/lima-cidata/param.env
+
+[Install]
+WantedBy=rancher-desktop.target

--- a/root/usr/local/lib/systemd/system/rancher-desktop-guest-agent.service
+++ b/root/usr/local/lib/systemd/system/rancher-desktop-guest-agent.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Rancher Desktop Guest Agent
 ConditionVirtualization=wsl
-Requires=network-namespace.service network-setup.service
-After=network-setup.service
+Requires=network-namespace.service network-setup.service params.service
+After=network-setup.service params.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/rancher-desktop

--- a/root/usr/local/libexec/rancher-desktop/container-engine-select.sh
+++ b/root/usr/local/libexec/rancher-desktop/container-engine-select.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This script is used by container-engine-select.service to start whichever
+# container engine is selected.
+
+set -o errexit -o pipefail -o nounset
+
+containerd_units=(
+    containerd.service
+    buildkitd.service
+    buildkitd.socket
+)
+
+moby_units=(
+    docker.service
+    docker.socket
+)
+
+printf 'Selecting container engine: "%s"\n' "${CONTAINER_ENGINE}"
+# Both `systemctl disable` and `systemctl add-requires` implicitly reload the
+# configuration, so we don't need to do it ourselves.  This can be confirmed by
+# using `journalctl` to read the messages around when this occurs.
+case "${CONTAINER_ENGINE}" in
+    containerd)
+        systemctl disable --now "${moby_units[@]}"
+        systemctl add-requires container-engine.target "${containerd_units[@]}"
+        ;;
+    moby)
+        systemctl disable --now "${containerd_units[@]}"
+        systemctl add-requires container-engine.target "${moby_units[@]}"
+        ;;
+    *)
+        printf 'Unknown container engine: "%s"\n' "${CONTAINER_ENGINE}" >&2
+        exit 1
+        ;;
+esac
+
+# Re-start container-engine.target so it picks up the newly-added requires.
+systemctl start --no-block container-engine.target

--- a/root/usr/local/libexec/rancher-desktop/k3s-install.sh
+++ b/root/usr/local/libexec/rancher-desktop/k3s-install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This script is executed by `k3s-install.service` to install k3s.
+# KUBERNETES_VERSION should be set (via `params.service`).
+set -o errexit -o pipefail -o nounset
+
+info() {
+    printf "\e[1;34m[INFO]\e[0m: %s\n" "$*" >&2
+}
+
+error() {
+    printf "\e[1;31m[ERROR]\e[0m: %s\n" "$*" >&2
+}
+
+find_version() {
+    if [[ ! -x /usr/local/bin/k3s ]]; then
+        info "K3s is not installed"
+        return
+    fi
+    # awk must read to EOF; `{print; exit}` closes the pipe while k3s
+    # is still writing, and the SIGPIPE propagates via pipefail + errexit.
+    /usr/local/bin/k3s --version 2>/dev/null | awk '/^k3s version/ { print $3 }'
+}
+
+install_k3s() {
+    export INSTALL_K3S_VERSION=v${KUBERNETES_VERSION}+k3s1
+    local INSTALLED_VERSION
+    INSTALLED_VERSION="$(find_version)"
+    if [[ "${INSTALLED_VERSION}" == "${INSTALL_K3S_VERSION}" ]]; then
+        info "K3s ${INSTALL_K3S_VERSION} is already installed; skipping install"
+        return
+    fi
+
+    # K3s needs to be (re-)installed; stop it if it is running.
+    if systemctl is-active --quiet k3s.service; then
+        info "Stopping k3s"
+        systemctl stop k3s.service
+    fi
+
+    # Don't enable k3s at install time; add it as a want of
+    # rancher-desktop.target instead.
+    export INSTALL_K3S_SKIP_ENABLE=true
+
+    (
+        export PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin
+        curl --fail --silent --show-error --location --connect-timeout 10 --max-time 60 \
+            https://get.k3s.io | sh -
+    )
+}
+
+# Remove stale kubeconfig so k3s regenerates it on start.  We will always end up
+# restarting it by the time we exit this script successfully.  (If we fail, then
+# systemd will restart us before proceeding with starting `k3s.service` anyway.)
+rm -f /etc/rancher/k3s/k3s.yaml
+
+# Prevent k3s from being enabled with the old version if the install fails;
+# we will re-enable it after a successful install.  This also prevents k3s
+# from being started with the wrong container engine options.  This does not
+# stop a running k3s, in case it is already at the correct version.
+if systemctl is-enabled --quiet k3s.service; then
+    info "Disabling k3s.service"
+    systemctl disable k3s.service
+fi
+
+install_k3s
+
+# Set the container engine options for k3s.
+info "Configuring k3s for ${CONTAINER_ENGINE}"
+case "${CONTAINER_ENGINE}" in
+    containerd)
+        echo > /etc/systemd/system/k3s.service.env \
+            "K3S_CONTAINER_ENGINE_OPTIONS=--container-runtime-endpoint /run/k3s/containerd/containerd.sock"
+        ;;
+    moby)
+        echo > /etc/systemd/system/k3s.service.env \
+            "K3S_CONTAINER_ENGINE_OPTIONS=--docker"
+        ;;
+    *)
+        error "Unknown container engine: ${CONTAINER_ENGINE}"
+        exit 1
+        ;;
+esac
+
+# Enable the k3s service (by marking it as a wanted by rancher-desktop.target)
+# and start it.  It still waits for k3s-install.service (i.e. this process) to
+# finish first.
+info "Enabling k3s.service"
+systemctl add-wants rancher-desktop.target k3s.service
+# `systemctl add-wants` implicitly reloads the configuration.
+# (Re-)start k3s so it picks up the new container engine options.  It won't
+# actually start until this unit finishes.
+systemctl restart --no-block k3s.service


### PR DESCRIPTION
This implements installing k3s using systemd units instead of doing it from RDD via a provisioning script; it replaces https://github.com/rancher-sandbox/rancher-desktop-daemon/blob/e2f89d5d0d68307bad771de5c46daeb2f5f7514f/pkg/controllers/app/app/lima-template.yaml#L33-L120

This mainly provides a few advantages:
- Because it's systemd-managed, we ensure that everything is correctly ordered, and is run as soon as its preconditions are met.
- systemd also manages retries (e.g. if the k3s download fails) transparently.
- We can use `systemd-analyze plot` to produce boot timings such as [this (Windows)](https://github.com/user-attachments/assets/4aa4bbe2-aa37-4a62-a7ec-8aa22359d510).  Also `systemd-analyze dot` for [dependencies](https://github.com/user-attachments/assets/5c099e3f-f743-4242-9528-b20cd0cf767c). (Note that varies based on whether containerd or moby is enabled.)

Things to test (which work):
- Enabling k3s from a blank slate (i.e. it downloads correctly)
- Changing container engines (k3s waits for whichever is selected to finish before starting)

When testing, please remember to remove the provisioning scripts linked at the top.  You may need to put in dummy things to pass lima validation.