### PR TITLE
networking: opt-in vm-switch packet tracing and configurable logfile append-mode

### DIFF
--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -42,16 +42,17 @@ import (
 )
 
 var options struct {
-	debug            bool
-	vmSwitchPath     string
-	unshareArg       string
-	vmSwitchLogFile  string
-	dhcpScript       string
-	logFile          string
-	namespaceService string
-	tapIface         string
-	subnet           string
-	tapDeviceMacAddr string
+	debug                 bool
+	vmSwitchPath          string
+	unshareArg            string
+	vmSwitchLogFile       string
+	vmSwitchLogFileAppend bool
+	dhcpScript            string
+	logFile               string
+	namespaceService      string
+	tapIface              string
+	subnet                string
+	tapDeviceMacAddr      string
 }
 
 const (
@@ -213,6 +214,7 @@ func initializeFlags() {
 	flag.StringVar(&options.dhcpScript, "dhcp-script", "", "script to run on DHCP events")
 	flag.StringVar(&options.vmSwitchPath, "vm-switch-path", "", "the path to the vm-switch binary that will run in a new namespace")
 	flag.StringVar(&options.vmSwitchLogFile, "vm-switch-logfile", "", "path to the logfile for vm-switch process")
+	flag.BoolVar(&options.vmSwitchLogFileAppend, "vm-switch-logfile-append", false, "append to the vm-switch logfile instead of truncating it on start")
 	flag.StringVar(&options.unshareArg, "unshare-arg", "", "the command argument to pass to the unshare program")
 	flag.StringVar(&options.logFile, "logfile", "/var/log/network-setup.log", "path to the logfile for network setup process")
 	flag.Parse()
@@ -224,7 +226,7 @@ func setupLogging(logFile string) error {
 		// not work correctly inside a systemd service.
 		logrus.StandardLogger().SetOutput(os.Stdout)
 	} else {
-		if err := log.SetOutputFile(logFile, logrus.StandardLogger()); err != nil {
+		if err := log.SetOutputFile(logFile, false, logrus.StandardLogger()); err != nil {
 			return fmt.Errorf("setting logger's output file failed: %w", err)
 		}
 	}
@@ -263,6 +265,9 @@ func configureVMSwitch(
 	}
 	if options.debug {
 		args = append(args, "-debug")
+	}
+	if options.vmSwitchLogFileAppend {
+		args = append(args, "-logfile-append")
 	}
 
 	//nolint:gosec // Arguments are ultimately controlled by our configs.

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -43,6 +43,7 @@ import (
 
 var options struct {
 	debug                 bool
+	tracePackets          bool
 	vmSwitchPath          string
 	unshareArg            string
 	vmSwitchLogFile       string
@@ -205,6 +206,7 @@ func main() {
 
 func initializeFlags() {
 	flag.BoolVar(&options.debug, "debug", false, "enable additional debugging")
+	flag.BoolVar(&options.tracePackets, "trace-packets", false, "forward per-packet tracing to the vm-switch process")
 	flag.StringVar(&options.namespaceService, "namespace-service", defaultNamespaceService, "systemd service which creates the network namespace")
 	flag.StringVar(&options.tapIface, "tap-interface", defaultTapDevice, "tap interface name, eg. eth0, eth1")
 	flag.StringVar(&options.subnet, "subnet", config.DefaultSubnet,
@@ -265,6 +267,9 @@ func configureVMSwitch(
 	}
 	if options.debug {
 		args = append(args, "-debug")
+	}
+	if options.tracePackets {
+		args = append(args, "-trace-packets")
 	}
 	if options.vmSwitchLogFileAppend {
 		args = append(args, "-logfile-append")

--- a/src/go/networking/cmd/proxy/wsl_integration_linux.go
+++ b/src/go/networking/cmd/proxy/wsl_integration_linux.go
@@ -90,7 +90,7 @@ func main() {
 }
 
 func setupLogging(logFile string) {
-	if err := log.SetOutputFile(logFile, logrus.StandardLogger()); err != nil {
+	if err := log.SetOutputFile(logFile, false, logrus.StandardLogger()); err != nil {
 		logrus.Fatalf("setting logger's output file failed: %v", err)
 	}
 

--- a/src/go/networking/cmd/vm/switch_linux.go
+++ b/src/go/networking/cmd/vm/switch_linux.go
@@ -102,8 +102,14 @@ func main() {
 	signal.Notify(traceSigCh, syscall.SIGUSR1)
 	go func() {
 		for range traceSigCh {
-			enabled := !tracePackets.Load()
-			tracePackets.Store(enabled)
+			var enabled bool
+			for {
+				old := tracePackets.Load()
+				enabled = !old
+				if tracePackets.CompareAndSwap(old, enabled) {
+					break
+				}
+			}
 			logrus.Infof("SIGUSR1 received: per-packet tracing is now %t", enabled)
 		}
 	}()

--- a/src/go/networking/cmd/vm/switch_linux.go
+++ b/src/go/networking/cmd/vm/switch_linux.go
@@ -45,6 +45,7 @@ var (
 	dhcpScript       string
 	tapIface         string
 	logFile          string
+	logFileAppend    bool
 	subnet           string
 	tapDeviceMacAddr string
 )
@@ -65,9 +66,10 @@ func main() {
 	flag.StringVar(&subnet, "subnet", config.DefaultSubnet,
 		fmt.Sprintf("Subnet range with CIDR suffix that is associated to the tap interface, e,g: %s", config.DefaultSubnet))
 	flag.StringVar(&logFile, "logfile", "/var/log/vm-switch.log", "path to vm-switch process logfile")
+	flag.BoolVar(&logFileAppend, "logfile-append", false, "append to the logfile instead of truncating it on start")
 	flag.Parse()
 
-	if err := log.SetOutputFile(logFile, logrus.StandardLogger()); err != nil {
+	if err := log.SetOutputFile(logFile, logFileAppend, logrus.StandardLogger()); err != nil {
 		logrus.Fatalf("setting logger's output file failed: %v", err)
 	}
 

--- a/src/go/networking/cmd/vm/switch_linux.go
+++ b/src/go/networking/cmd/vm/switch_linux.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -56,8 +57,17 @@ const (
 	maxMTU           = 4000
 )
 
+var (
+	// traceFlag is the startup value of the -trace-packets flag.
+	traceFlag bool
+	// tracePackets gates per-packet logging. It is initialized from traceFlag
+	// and can be toggled at runtime by sending SIGUSR1 to this process.
+	tracePackets atomic.Bool
+)
+
 func main() {
 	flag.BoolVar(&debug, "debug", false, "enable debug flag")
+	flag.BoolVar(&traceFlag, "trace-packets", false, "log a decode of every packet (very verbose); can also be toggled at runtime via SIGUSR1")
 	flag.StringVar(&tapIface, "tap-interface", defaultTapDevice, "tap interface name, eg. eth0, eth1")
 	flag.IntVar(&vsockFD, "vsock-fd", defaultVsockFD, "file descriptor for vsock connection")
 	flag.StringVar(&dhcpScript, "dhcp-script", "", "script to run on DHCP events")
@@ -76,6 +86,27 @@ func main() {
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	// Per-packet tracing is intentionally separate from -debug (it is extremely
+	// verbose and can fill the disk). It starts in the state requested by
+	// -trace-packets and can be flipped on/off at runtime, without restarting
+	// the network stack, by sending SIGUSR1.
+	//
+	// vm-switch runs in the top-level WSL (init) PID namespace, so the signal
+	// must be sent from there, e.g. from the Windows host:
+	//   wsl -d rancher-desktop --exec sh -c 'kill -USR1 $(pgrep vm-switch)'
+	// It is NOT reachable via `rdctl shell`, which enters the Rancher Desktop
+	// network namespace where vm-switch is not visible (pgrep finds nothing).
+	tracePackets.Store(traceFlag)
+	traceSigCh := make(chan os.Signal, 1)
+	signal.Notify(traceSigCh, syscall.SIGUSR1)
+	go func() {
+		for range traceSigCh {
+			enabled := !tracePackets.Load()
+			tracePackets.Store(enabled)
+			logrus.Infof("SIGUSR1 received: per-packet tracing is now %t", enabled)
+		}
+	}()
 
 	// the FD is passed-in as an extra arg from exec.Command
 	// of the parent process. This is for the AF_VSOCK connection that
@@ -227,9 +258,9 @@ func rx(ctx context.Context, conn io.Writer, tap *water.Interface, errCh chan er
 				return
 			}
 
-			if debug {
+			if tracePackets.Load() {
 				packet := gopacket.NewPacket(frame, layers.LayerTypeEthernet, gopacket.Default)
-				logrus.Infof("wrote packet (vm -> host %d): %s", size, packet.String())
+				logrus.Infof("wrote packet (vm -> host %d): %s", n, packet.String())
 			}
 		}
 	}
@@ -275,7 +306,7 @@ func tx(ctx context.Context, conn io.Reader, tap *water.Interface, errCh chan er
 				return
 			}
 
-			if debug {
+			if tracePackets.Load() {
 				packet := gopacket.NewPacket(buf[:size], layers.LayerTypeEthernet, gopacket.Default)
 				logrus.Infof("read packet (host -> vm %d): %s", size, packet.String())
 			}

--- a/src/go/networking/pkg/log/log.go
+++ b/src/go/networking/pkg/log/log.go
@@ -21,9 +21,15 @@ import (
 
 const fileMode = 0o666
 
-// SetOutputFile sets the logger output with a given file
-func SetOutputFile(filePath string, logger *logrus.Logger) error {
-	logFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
+// SetOutputFile points the logger at filePath. When appendMode is true the file
+// is opened for appending, so its contents survive a process restart; otherwise
+// the file is truncated on open.
+func SetOutputFile(filePath string, appendMode bool, logger *logrus.Logger) error {
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if appendMode {
+		flags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	}
+	logFile, err := os.OpenFile(filePath, flags, fileMode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Two `vm-switch` logging changes that together make `vm-switch.log` usable for diagnosing WSL2 networking.

## 1. Opt-in per-packet tracing (port of rancher-desktop `63baf19a0`)

`vm-switch` logged a gopacket decode of every packet in both directions whenever started with `-debug`, which `network-setup` propagates — so any debug session got a per-packet firehose that grows `vm-switch.log` without bound. This splits per-packet tracing into a `-trace-packets` flag (default off, toggleable at runtime via `SIGUSR1`); `-debug` now only raises the log level. `network-setup` forwards `-trace-packets`. Also fixes the rx trace line, which logged the 2-byte length slice instead of the length.

## 2. Configurable append-mode logfile

`vm-switch` opens its logfile with `O_TRUNC`, so each restart discards the previous run's log. A `-logfile-append` flag (default off, preserving truncation) opens it with `O_APPEND` instead; `network-setup` forwards it via `-vm-switch-logfile-append`.

## Why

Default behaviour is unchanged for both: no per-packet spam unless asked, and the logfile is still truncated on start, so regular runs stay bounded. Together they let a diagnostic context (CI) capture the full `vm-switch` reconnect history — otherwise lost to truncation when the WSL2 host-switch relay flaps and the VM restarts every few minutes — without changing log behaviour for normal users. The CI wiring that opts in is a follow-up.