### PR TITLE
k3s.service: Fix command line override when using network namespaces

### DIFF
--- a/root/usr/local/lib/systemd/system/k3s.service.d/command-override.conf
+++ b/root/usr/local/lib/systemd/system/k3s.service.d/command-override.conf
@@ -1,6 +1,7 @@
 # Override the k3s command line
 [Service]
 ExecStart=
+# This should be kept in sync with `network-namespace.conf`.
 ExecStart=/usr/local/bin/k3s server \
     --https-listen-port $KUBERNETES_PORT \
     $K3S_CONTAINER_ENGINE_OPTIONS

--- a/root/usr/local/lib/systemd/system/k3s.service.d/network-namespace.conf
+++ b/root/usr/local/lib/systemd/system/k3s.service.d/network-namespace.conf
@@ -5,4 +5,7 @@ After=network-setup.service
 
 [Service]
 ExecStart=
-ExecStart=/usr/local/bin/wsl-exec /usr/local/bin/k3s server
+# This should be kept in sync with `command-override.conf`.
+ExecStart=/usr/local/bin/wsl-exec /usr/local/bin/k3s server \
+    --https-listen-port $KUBERNETES_PORT \
+    $K3S_CONTAINER_ENGINE_OPTIONS


### PR DESCRIPTION
We have a `command-override.conf`, which is then overriden by `network-namespace.conf` (because `n` comes after `c`).