### PR TITLE
RD guest agent: Set Kubernetes port

### DIFF
--- a/root/usr/local/lib/systemd/system/rancher-desktop-guest-agent.service
+++ b/root/usr/local/lib/systemd/system/rancher-desktop-guest-agent.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/run/systemd/system/%n.d/config.env
 ExecStart=/usr/local/bin/wsl-exec \
     /usr/local/bin/rancher-desktop-guest-agent \
     -kubernetes=${KUBERNETES_ENABLED} \
+    -k8sAPIPort=${KUBERNETES_PORT} \
     -docker=${DOCKER_ENABLED} \
     -containerd=${CONTAINERD_ENABLED} \
     -debug


### PR DESCRIPTION
We previously fixed k3s on WSL to be able to accept the Kubernetes port as configured; however, we did not fix the matching guest agent configuration to use the new port to communicate with Kubernetes.  Fix that to resolve errors probing for Kubernetes.

Fixes: 8b79635b6fcc06f74ca6c43367aa4bfe275bdc19