### PR TITLE
Format Kubernetes status debug errors correctly

### DIFF
--- a/src/go/guestagent/pkg/kube/servicewatcher_linux.go
+++ b/src/go/guestagent/pkg/kube/servicewatcher_linux.go
@@ -89,8 +89,7 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 			if errors.As(err, &statusError) {
 				log.Debugw("kubernetes: got status error", log.Fields{
 					"status": statusError.Status(),
-					//nolint:govet // .DebugError() returns a format string plus fields.
-					"debug": fmt.Sprintf(statusError.DebugError()),
+					"debug":  statusDebugString(statusError),
 				})
 			}
 			log.Errorw("kubernetes: unexpected error watching", log.Fields{
@@ -120,6 +119,11 @@ func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan ev
 	}()
 
 	return eventCh, errorCh, nil
+}
+
+func statusDebugString(err *apierrors.StatusError) string {
+	format, args := err.DebugError()
+	return fmt.Sprintf(format, args...)
 }
 
 // handleUpdate examines the old and new services, calculating the difference

--- a/src/go/guestagent/pkg/kube/servicewatcher_linux_test.go‎
+++ b/src/go/guestagent/pkg/kube/servicewatcher_linux_test.go‎
@@ -1,0 +1,42 @@
+/*
+Copyright © 2026 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStatusDebugStringFormatsDebugErrorArgs(t *testing.T) {
+	err := &apierrors.StatusError{
+		ErrStatus: v1.Status{
+			Status:  v1.StatusFailure,
+			Message: "test status message",
+			Reason:  v1.StatusReasonForbidden,
+			Code:    403,
+		},
+	}
+
+	actual := statusDebugString(err)
+
+	if strings.Contains(actual, "%!") {
+		t.Fatalf("status debug string contains fmt error: %s", actual)
+	}
+	if !strings.Contains(actual, "test status message") {
+		t.Fatalf("status debug string did not include status message: %s", actual)
+	}
+}


### PR DESCRIPTION
Fixes the kubernetes status debug errors to show correctly; the changes are based on [here](https://github.com/rancher-sandbox/rancher-desktop/pull/10274). 