### PR TITLE
Make vsock listen and handshake ports configurable

### DIFF
--- a/src/go/networking/cmd/host/switch_windows.go
+++ b/src/go/networking/cmd/host/switch_windows.go
@@ -37,16 +37,14 @@ import (
 )
 
 var (
-	debug             bool
-	virtualSubnet     string
-	staticPortForward arrayFlags
+	debug              bool
+	virtualSubnet      string
+	staticPortForward  arrayFlags
+	vsockListenPort    int
+	vsockHandshakePort int
 )
 
-const (
-	vsockListenPort    = 6656
-	vsockHandshakePort = 6669
-	timeoutSeconds     = 5 * 60
-)
+const timeoutSeconds = 5 * 60
 
 func main() {
 	flag.BoolVar(&debug, "debug", false, "enable additional debugging")
@@ -54,6 +52,8 @@ func main() {
 		fmt.Sprintf("Subnet range with CIDR suffix for virtual network, e,g: %s", config.DefaultSubnet))
 	flag.Var(&staticPortForward, "port-forward",
 		"List of ports that needs to be pre forwarded to the WSL VM in Host:Port=Guest:Port format e.g: 127.0.0.1:2222=192.168.127.2:22")
+	flag.IntVar(&vsockHandshakePort, "vsock-handshake-port", 6670, "port for vsock handshake")
+	flag.IntVar(&vsockListenPort, "vsock-listen-port", 6657, "port for vsock to listen on for connections from the VM")
 	flag.Parse()
 
 	if debug {
@@ -89,7 +89,7 @@ func runSwitch(subnet config.Subnet, portForwarding map[string]string) error {
 
 	cfg := newConfig(subnet, portForwarding, debug)
 
-	ln, err := vsockHandshake(ctx, vsockHandshakePort, vsock.SignaturePhrase)
+	ln, err := vsockHandshake(ctx, uint32(vsockHandshakePort), uint32(vsockListenPort), vsock.SignaturePhrase)
 	if err != nil {
 		return fmt.Errorf("handshake with peer process failed: %w", err)
 	}
@@ -185,7 +185,7 @@ func httpServe(ctx context.Context, g *errgroup.Group, ln net.Listener, mux http
 	})
 }
 
-func vsockHandshake(ctx context.Context, handshakePort uint32, signature string) (net.Listener, error) {
+func vsockHandshake(ctx context.Context, handshakePort, vsockListenPort uint32, signature string) (net.Listener, error) {
 	bailout := time.After(time.Second * timeoutSeconds)
 	vmGUID, err := vsock.GetVMGUID(ctx, signature, handshakePort, bailout)
 	if err != nil {
@@ -196,7 +196,7 @@ func vsockHandshake(ctx context.Context, handshakePort uint32, signature string)
 	if err != nil {
 		return nil, fmt.Errorf("creating vsock listener for host-switch failed: %w", err)
 	}
-	err = signalVsockListenerReady(vmGUID, vsockHandshakePort)
+	err = signalVsockListenerReady(vmGUID, handshakePort)
 	if err != nil {
 		return nil, fmt.Errorf("sending %s signal to peer process failed: %w", vsock.ReadySignal, err)
 	}

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -54,20 +54,19 @@ var options struct {
 	tapIface              string
 	subnet                string
 	tapDeviceMacAddr      string
+	vsockHandshakePort    int
+	vsockDialPort         int
 }
 
 const (
 	nsenter                 = "/usr/bin/nsenter"
 	unshare                 = "/usr/bin/unshare"
-	vsockHandshakePort      = 6669
-	vsockDialPort           = 6656
 	defaultTapDevice        = "eth0"
 	WSLVeth                 = "veth-rd-wsl"
 	WSLVethIP               = "192.168.143.2"
 	namespaceVeth           = "veth-rd-ns"
 	namespaceVethIP         = "192.168.143.1"
 	defaultNamespaceService = "network-namespace.service"
-	defaultNamespacePID     = 1
 	cidrOnes                = 24
 	cidrBits                = 32
 	stdout                  = "/dev/stdout"
@@ -100,12 +99,12 @@ func run() error {
 		return fmt.Errorf("failed to handshake with host-switch: %w", err)
 	}
 
-	logrus.Debugf("attempting to connect to the host on CID: %v and Port: %d", vsock.CIDHost, vsockDialPort)
-	vsockConn, err := vsock.Dial(vsock.CIDHost, vsockDialPort)
+	logrus.Debugf("attempting to connect to the host on CID: %v and Port: %d", vsock.CIDHost, options.vsockDialPort)
+	vsockConn, err := vsock.Dial(vsock.CIDHost, uint32(options.vsockDialPort))
 	if err != nil {
 		return err
 	}
-	logrus.Debugf("successful connection to host on CID: %v and Port: %d: connection: %+v", vsock.CIDHost, vsockDialPort, vsockConn)
+	logrus.Debugf("successful connection to host on CID: %v and Port: %d: connection: %+v", vsock.CIDHost, options.vsockDialPort, vsockConn)
 
 	connFile, err := vsockConn.File()
 	if err != nil {
@@ -219,6 +218,8 @@ func initializeFlags() {
 	flag.BoolVar(&options.vmSwitchLogFileAppend, "vm-switch-logfile-append", false, "append to the vm-switch logfile instead of truncating it on start")
 	flag.StringVar(&options.unshareArg, "unshare-arg", "", "the command argument to pass to the unshare program")
 	flag.StringVar(&options.logFile, "logfile", "/var/log/network-setup.log", "path to the logfile for network setup process")
+	flag.IntVar(&options.vsockHandshakePort, "vsock-handshake-port", 6670, "port for vsock handshake")
+	flag.IntVar(&options.vsockDialPort, "vsock-dial-port", 6657, "host switch port for vsock dial")
 	flag.Parse()
 }
 
@@ -369,7 +370,7 @@ func writeWSLInitPid(pid int) error {
 
 func listenForHandshake(ctx context.Context) error {
 	logrus.Info("starting handshake process with host-switch")
-	l, err := vsock.Listen(vsock.CIDAny, vsockHandshakePort)
+	l, err := vsock.Listen(vsock.CIDAny, uint32(options.vsockHandshakePort))
 	if err != nil {
 		return fmt.Errorf("failed to listen on handshake port: %w", err)
 	}

--- a/src/go/networking/pkg/vsock/constants.go
+++ b/src/go/networking/pkg/vsock/constants.go
@@ -14,6 +14,6 @@ limitations under the License.
 package vsock
 
 const (
-	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop/src/go/networking"
+	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop-opensuse/src/go/networking"
 	ReadySignal     = "READY"
 )


### PR DESCRIPTION
Replace hardcoded vsock port constants with CLI flags on both the host (switch_windows.go) and Linux (setup_linux.go) sides. Update default ports to 6657 (listen/dial) and 6670 (handshake) to avoid conflicts. Update SignaturePhrase to make it unique to RD2.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-2/issues/483