### PR TITLE
Add golangci-lint CI workflow and fix pre-existing lint issues

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches: [ '**' ]
+    tags-ignore: [ 'v*', 'test-v*' ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: stable
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b /usr/local/bin v2.10.1
+      - name: Lint Go
+        run: |
+          cd src/go/networking
+          GOOS=linux golangci-lint run ./cmd/network/... ./cmd/vm/... ./cmd/proxy/... ./pkg/...
+          GOOS=windows golangci-lint run ./cmd/host/...
+          cd $GITHUB_WORKSPACE/src/go/guestagent
+          GOOS=linux golangci-lint run ./...
+          cd $GITHUB_WORKSPACE/src/rd-init
+          GOOS=linux golangci-lint run ./...
+          cd $GITHUB_WORKSPACE/src/rdd-guest
+          GOOS=linux golangci-lint run ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,88 @@
+# golangci-lint configuration file.
+# https://golangci-lint.run/usage/configuration/
+version: "2"
+run:
+  concurrency: 6
+linters:
+  default: none
+  enable:
+  - bodyclose
+  - copyloopvar
+  - dogsled
+  - dupl
+  - errcheck
+  - goconst
+  - gocritic
+  - goprintffuncname
+  - gosec
+  - govet
+  - ineffassign
+  - misspell
+  - mnd
+  - nakedret
+  - noctx
+  - nolintlint
+  - staticcheck
+  - unconvert
+  - unparam
+  - unused
+  - whitespace
+  settings:
+    gocritic:
+      disabled-checks:
+      - appendCombine
+      - sloppyReassign
+      - unlabelStmt
+      - rangeValCopy
+      - hugeParam
+      - importShadow
+      - sprintfQuotedString
+      - builtinShadow
+      - filepathJoin
+      - exitAfterDefer
+      enabled-tags:
+      - diagnostic
+      - performance
+      - style
+      - opinionated
+      - experimental
+      settings:
+        ifElseChain:
+          minThreshold: 3
+    gosec:
+      excludes:
+      - G115 # integer overflow conversion is intentional in low-level system code
+      - G306 # file permissions intentionally set above 0600 for world-readable config files
+      - G704 # SSRF taint analysis is a false positive for application HTTP clients
+    mnd:
+      ignored-numbers:
+      - "0o400"
+      - "0o600"
+      - "0o644"
+      - "0o700"
+      - "0o755"
+      - "2"
+      - "3"
+      - "5"
+      ignored-functions:
+      - "make"
+      - "os.WriteFile"
+      - "os.MkdirAll"
+      - "net.IPv4"
+    staticcheck:
+      checks:
+      - all
+      - -QF*
+      - -ST1001
+  exclusions:
+    presets:
+    - common-false-positives
+    - legacy
+    - std-error-handling
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+  - gofmt
+  - gofumpt

--- a/src/go/guestagent/Makefile
+++ b/src/go/guestagent/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	GOOS=linux golangci-lint run ./...

--- a/src/go/guestagent/pkg/containerd/events_stub.go
+++ b/src/go/guestagent/pkg/containerd/events_stub.go
@@ -22,8 +22,7 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/guestagent/pkg/tracker"
 )
 
-type EventMonitor struct {
-}
+type EventMonitor struct{}
 
 func NewEventMonitor(containerdSock string, portTracker tracker.Tracker) (*EventMonitor, error) {
 	panic("not implement for non-Linux")

--- a/src/go/guestagent/pkg/iptables/iptables.go
+++ b/src/go/guestagent/pkg/iptables/iptables.go
@@ -132,8 +132,7 @@ func (i *Iptables) ForwardPorts() error {
 // comparePorts compares the old and new ports to find those added or removed.
 // This function is mostly lifted from lima (github.com/lima-vm/lima) which is
 // licensed under the Apache 2.
-func comparePorts(oldPorts, newPorts []limaiptables.Entry) ([]limaiptables.Entry, []limaiptables.Entry) {
-	var added, removed []limaiptables.Entry
+func comparePorts(oldPorts, newPorts []limaiptables.Entry) (added, removed []limaiptables.Entry) {
 	oldPortMap := make(map[string]limaiptables.Entry, len(oldPorts))
 	portExistMap := make(map[string]bool, len(oldPorts))
 	for _, oldPort := range oldPorts {

--- a/src/go/guestagent/pkg/kube/servicewatcher_linux.go
+++ b/src/go/guestagent/pkg/kube/servicewatcher_linux.go
@@ -42,7 +42,7 @@ type event struct {
 
 // watchServices monitors for NodePort and LoadBalancer services; after listing all service ports
 // initially, it reports service ports being added or deleted.
-func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan event, <-chan error, error) {
+func watchServices(ctx context.Context, client *kubernetes.Clientset) (<-chan event, <-chan error, error) { //nolint:gocritic
 	eventCh := make(chan event)
 	errorCh := make(chan error)
 	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Hour)

--- a/src/go/guestagent/pkg/utils/utils.go
+++ b/src/go/guestagent/pkg/utils/utils.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package utils provides utility functions for the guestagent.
 package utils
 
 import (

--- a/src/go/networking/Makefile
+++ b/src/go/networking/Makefile
@@ -31,6 +31,11 @@ wsl-proxy: bin/wsl-proxy
 fmt:
 	gofmt -l -s -w .
 
+.PHONY: lint
+lint:
+	GOOS=windows golangci-lint run ./cmd/host/...
+	GOOS=linux golangci-lint run ./cmd/network/... ./cmd/vm/... ./cmd/proxy/... ./pkg/...
+
 .PHONY: clean
 clean:
 	rm -rf ./bin

--- a/src/go/networking/cmd/host/switch_windows.go
+++ b/src/go/networking/cmd/host/switch_windows.go
@@ -174,8 +174,8 @@ func httpServe(ctx context.Context, g *errgroup.Group, ln net.Listener, mux http
 	g.Go(func() error {
 		s := &http.Server{
 			Handler:      mux,
-			ReadTimeout:  10 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			ReadTimeout:  10 * time.Second, //nolint:mnd // 10s is a standard HTTP server timeout
+			WriteTimeout: 10 * time.Second, //nolint:mnd // 10s is a standard HTTP server timeout
 		}
 		err := s.Serve(ln)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -81,7 +82,7 @@ func run() error {
 	}
 
 	if options.vmSwitchPath == "" {
-		return fmt.Errorf("path to the vm-switch process must be provided")
+		return errors.New("path to the vm-switch process must be provided")
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), unix.SIGTERM, unix.SIGHUP, unix.SIGQUIT)
@@ -136,7 +137,7 @@ func run() error {
 	} else {
 		// Running under OpenRC
 		if options.unshareArg == "" {
-			return fmt.Errorf("unshare program arg must be provided")
+			return errors.New("unshare program arg must be provided")
 		}
 
 		peerNS, err = configureNamespace()
@@ -250,7 +251,8 @@ func configureVMSwitch(
 	subnet,
 	tapDevMacAddr,
 	dhcpScript string,
-	connFile *os.File) *exec.Cmd {
+	connFile *os.File,
+) *exec.Cmd {
 	args := []string{
 		vmSwitchPath,
 		"-tap-interface",

--- a/src/go/networking/pkg/config/config.go
+++ b/src/go/networking/pkg/config/config.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// config contains all the configuration that is required by host switch.
+// Package config contains all the configuration that is required by host switch.
 package config
 
 import (
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	// Subnet range that is used by default if
+	// DefaultSubnet is the subnet range that is used by default if
 	// one is not provided through the arguments.
 	DefaultSubnet = "192.168.127.0/24"
-	// Reserved Mac Address for the tap device eth0 that
+	// TapDeviceMacAddr is the reserved Mac Address for the tap device eth0 that
 	// is used by vm switch during the tap device
 	// creation.
 	TapDeviceMacAddr   = "5a:94:ef:e4:0c:ee"

--- a/src/go/networking/pkg/log/log.go
+++ b/src/go/networking/pkg/log/log.go
@@ -1,3 +1,4 @@
+// Package log provides logging setup utilities for networking processes.
 package log
 
 /*

--- a/src/go/networking/pkg/portproxy/server.go
+++ b/src/go/networking/pkg/portproxy/server.go
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package portproxy implements a proxy server for forwarding TCP and UDP connections.
 package portproxy
 
 import (
@@ -31,11 +33,13 @@ import (
 	"github.com/rancher-sandbox/rancher-desktop/src/go/networking/pkg/utils"
 )
 
+// ProxyConfig holds the configuration for a PortProxy instance.
 type ProxyConfig struct {
 	UpstreamAddress string
 	UDPBufferSize   int
 }
 
+// PortProxy accepts connections and proxies them to the configured upstream.
 type PortProxy struct {
 	ctx            context.Context
 	config         *ProxyConfig
@@ -51,6 +55,7 @@ type PortProxy struct {
 	wg             sync.WaitGroup
 }
 
+// NewPortProxy creates a new PortProxy that accepts from listener and forwards to cfg.UpstreamAddress.
 func NewPortProxy(ctx context.Context, listener net.Listener, cfg *ProxyConfig) *PortProxy {
 	portProxy := &PortProxy{
 		ctx:             ctx,
@@ -64,6 +69,7 @@ func NewPortProxy(ctx context.Context, listener net.Listener, cfg *ProxyConfig) 
 	return portProxy
 }
 
+// Start begins accepting connections and proxying them to the upstream address.
 func (p *PortProxy) Start() error {
 	logrus.Infof("Proxy server started accepting on %s, forwarding to %s", p.listener.Addr(), p.config.UpstreamAddress)
 	for {
@@ -82,6 +88,7 @@ func (p *PortProxy) Start() error {
 	}
 }
 
+// UDPPortMappings returns the active UDP port-to-connection mappings.
 func (p *PortProxy) UDPPortMappings() map[int]*net.UDPConn {
 	p.udpConnMutex.Lock()
 	defer p.udpConnMutex.Unlock()
@@ -256,6 +263,7 @@ func (p *PortProxy) acceptTraffic(listener net.Listener, port string) {
 	}
 }
 
+// Close shuts down the proxy and releases all associated resources.
 func (p *PortProxy) Close() error {
 	// Close all the active listeners
 	p.cleanupListeners()

--- a/src/go/networking/pkg/portproxy/server_test.go
+++ b/src/go/networking/pkg/portproxy/server_test.go
@@ -55,7 +55,7 @@ func TestNewPortProxyUDP(t *testing.T) {
 		UDPBufferSize:   1024,
 	}
 	portProxy := portproxy.NewPortProxy(t.Context(), localListener, proxyConfig)
-	go portProxy.Start()
+	go func() { _ = portProxy.Start() }()
 
 	_, testPort, err := net.SplitHostPort(targetConn.LocalAddr().String())
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestNewPortProxyUDP(t *testing.T) {
 	_, err = sourceConn.Write([]byte(expectedString))
 	require.NoError(t, err)
 
-	targetConn.SetDeadline(time.Now().Add(time.Second * 5))
+	require.NoError(t, targetConn.SetDeadline(time.Now().Add(time.Second*5)))
 
 	b := make([]byte, len(expectedString))
 	n, _, err := targetConn.ReadFromUDP(b)
@@ -121,13 +121,14 @@ func TestNewPortProxyTCP(t *testing.T) {
 	defer listener.Close()
 
 	testServer := http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			fmt.Fprint(w, expectedResponse)
 		}),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	defer testServer.Close()
 	testServer.SetKeepAlivesEnabled(false)
-	go testServer.Serve(listener)
+	go func() { _ = testServer.Serve(listener) }()
 
 	_, testPort, err := net.SplitHostPort(listener.Addr().String())
 	require.NoError(t, err)
@@ -140,7 +141,7 @@ func TestNewPortProxyTCP(t *testing.T) {
 		UpstreamAddress: testServerIP,
 	}
 	portProxy := portproxy.NewPortProxy(t.Context(), localListener, proxyConfig)
-	go portProxy.Start()
+	go func() { _ = portProxy.Start() }()
 
 	getURL := fmt.Sprintf("http://localhost:%s", testPort)
 	resp, err := httpGetRequest(t.Context(), getURL)
@@ -201,7 +202,7 @@ func TestNewPortProxyTCP(t *testing.T) {
 }
 
 func httpGetRequest(ctx context.Context, url string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/networking/pkg/utils/pipe.go
+++ b/src/go/networking/pkg/utils/pipe.go
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package utils provides shared networking helper utilities.
 package utils
 
 import (
@@ -23,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Pipe forwards data bidirectionally between conn and the upstream TCP address.
 func Pipe(ctx context.Context, conn net.Conn, upstreamAddr string) {
 	dialer := net.Dialer{
 		Timeout: 5 * time.Second,

--- a/src/go/networking/pkg/vsock/constants.go
+++ b/src/go/networking/pkg/vsock/constants.go
@@ -11,8 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package vsock provides constants and utilities for vsock communication between host and VM.
 package vsock
 
+// vsock constants used for handshake and signaling between host and VM.
 const (
 	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop/src/go/networking"
 	ReadySignal     = "READY"

--- a/src/rd-init/Makefile
+++ b/src/rd-init/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	GOOS=linux golangci-lint run ./...

--- a/src/rd-init/main.go
+++ b/src/rd-init/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
-func runCommand(ctx context.Context, name string, arg... string) error {
+func runCommand(ctx context.Context, name string, arg ...string) error {
 	slog.DebugContext(ctx, "Running command", "name", name, "arg", arg)
 	cmd := exec.CommandContext(ctx, name, arg...)
 	cmd.Stdout = os.Stdout
@@ -23,7 +23,7 @@ func runCommand(ctx context.Context, name string, arg... string) error {
 
 func run(ctx context.Context) error {
 	var units []string
-	fns := []func(context.Context)([]string, error) {
+	fns := []func(context.Context) ([]string, error){
 		LoadMetadata,
 		LoadUserData,
 		LoadNetworkConfig,
@@ -86,7 +86,7 @@ func run(ctx context.Context) error {
 	return nil
 }
 
-func main () {
+func main() {
 	ctx := context.Background()
 	if err := run(ctx); err != nil {
 		slog.ErrorContext(ctx, "rd-init failed", "error", err)

--- a/src/rd-init/metadata.go
+++ b/src/rd-init/metadata.go
@@ -15,7 +15,7 @@ const (
 	metadataPath = "/mnt/lima-cidata/meta-data"
 )
 
-// Load /mnt/lima-cidata/meta-data
+// LoadMetadata loads /mnt/lima-cidata/meta-data.
 func LoadMetadata(ctx context.Context) ([]string, error) {
 	var metaData struct {
 		LocalHostName string `yaml:"local-hostname"`

--- a/src/rd-init/network.go
+++ b/src/rd-init/network.go
@@ -17,18 +17,18 @@ const (
 )
 
 var networkConfig struct {
-	Version uint `yaml:"version"`
+	Version   uint `yaml:"version"`
 	Ethernets map[string]struct {
 		Match struct {
 			MACAddress string `yaml:"macaddress"`
 		} `yaml:"match"`
-		DHCP4 bool `yaml:"dhcp4"`
-		SetName string `yaml:"set-name,omitempty"`
+		DHCP4          bool   `yaml:"dhcp4"`
+		SetName        string `yaml:"set-name,omitempty"`
 		DHCP4Overrides struct {
 			RouteMetric uint `yaml:"route-metric"`
 		} `yaml:"dhcp4-overrides"`
 		DHCPIdentifier string `yaml:"dhcp-identifier"`
-		NameServers struct {
+		NameServers    struct {
 			Addresses []net.IP `yaml:"addresses"`
 		} `yaml:"nameservers"`
 	} `yaml:"ethernets"`
@@ -52,7 +52,7 @@ func LoadNetworkConfig(ctx context.Context) ([]string, error) {
 				return nil, fmt.Errorf("network interface %q has set-name=%q but no match", name, ethernet.SetName)
 			}
 			slog.InfoContext(ctx, "renaming network interface", "name", ethernet.SetName)
-			contents := []string {
+			contents := []string{
 				"[Match]",
 				fmt.Sprintf("MACAddress=%s", ethernet.Match.MACAddress),
 				"[Link]",

--- a/src/rd-init/userdata.go
+++ b/src/rd-init/userdata.go
@@ -40,7 +40,7 @@ func escapeSystemdMountName(input string) string {
 	return result
 }
 
-// Load /mnt/lima-cidata/user-data; returns a list of systemd units that must
+// LoadUserData loads /mnt/lima-cidata/user-data; returns a list of systemd units that must
 // be started after.
 func LoadUserData(ctx context.Context) ([]string, error) {
 	var units []string
@@ -65,7 +65,7 @@ func LoadUserData(ctx context.Context) ([]string, error) {
 			Permissions string `yaml:"permissions"`
 		} `yaml:"write_files"`
 		ManageResolveConf bool `yaml:"manage_resolv_conf"`
-		ResolveConf struct {
+		ResolveConf       struct {
 			NameServers []string `yaml:"nameservers"`
 		} `yaml:"resolv_conf"`
 	}
@@ -117,7 +117,7 @@ func LoadUserData(ctx context.Context) ([]string, error) {
 			slog.InfoContext(ctx, "adding user to sudoers", "user", userEntry.Name)
 			err := os.WriteFile(
 				fmt.Sprintf("/etc/sudoers.d/90-lima-user-%s", userEntry.Name),
-				[]byte(userEntry.Name + " " + userEntry.Sudo),
+				[]byte(userEntry.Name+" "+userEntry.Sudo),
 				0o400)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create sudoers file for %q: %w", userEntry.Name, err)
@@ -133,7 +133,8 @@ func LoadUserData(ctx context.Context) ([]string, error) {
 		if err := os.Chown(sshDir, int(uid), int(gid)); err != nil {
 			return nil, err
 		}
-		sshAuthorizedKeys := append(userEntry.SSHAuthorizedKeys, userEntry.SSHAuthorizedKeysFallback...)
+		sshAuthorizedKeys := userEntry.SSHAuthorizedKeys
+		sshAuthorizedKeys = append(sshAuthorizedKeys, userEntry.SSHAuthorizedKeysFallback...)
 		err = os.WriteFile(
 			filepath.Join(sshDir, "authorized_keys"),
 			[]byte(strings.Join(sshAuthorizedKeys, "\n")),
@@ -172,7 +173,7 @@ func LoadUserData(ctx context.Context) ([]string, error) {
 		if err := os.WriteFile(filename, output, 0o644); err != nil {
 			return nil, fmt.Errorf("failed to create mount unit %q: %w", filename, err)
 		}
-		units = append(units, escapeSystemdMountName(mount[1]) + ".mount")
+		units = append(units, escapeSystemdMountName(mount[1])+".mount")
 	}
 
 	// Process files

--- a/src/rdd-guest/Makefile
+++ b/src/rdd-guest/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	GOOS=linux golangci-lint run ./...


### PR DESCRIPTION
Add `.golangci.yml` config, a lint Makefile target, and a GitHub Actions workflow that lints all Go packages on push and PR. Fix pre-existing lint issues across the codebase to make CI pass cleanly.

Fixes: https://github.com/rancher-sandbox/rancher-desktop-2/issues/490