### PR TITLE
CI: Add a workflow to run BATS on build

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -1,0 +1,261 @@
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+permissions:
+  actions: read
+jobs:
+  bats:
+    name: BATS
+    strategy:
+      fail-fast: false
+      matrix:
+        # Using macos-intel because macos-aarch64 does not have nested virtualization.
+        runs-on:
+        - macos-15-intel
+        - ubuntu-latest
+        - windows-latest
+        # We only need to test that the VM starts with the new image.
+        suite:
+        - bats-lima
+        include:
+        # Attach the image name to use per runner OS.
+        - { runs-on: macos-15-intel, type: raw }
+        - { runs-on: ubuntu-latest,  type: qcow2 }
+        - { runs-on: windows-latest, type: tar }
+    runs-on: ${{ matrix.runs-on }}
+    # Only run this workflow if the build succeeded, as otherwise there would be
+    # no image to test with.
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+    - name: "Linux: Install prerequisites"
+      if: runner.os == 'Linux'
+      working-directory: ${{ runner.temp }}
+      run: |
+        # Enable KVM access
+        test -w /dev/kvm || sudo chmod a+rwx /dev/kvm
+
+        # Set unprivileged port start to 80
+        if test $(cat /proc/sys/net/ipv4/ip_unprivileged_port_start) -gt 80; then
+          sudo sh -c 'echo 80 > /proc/sys/net/ipv4/ip_unprivileged_port_start'
+        fi
+
+        # Install QEMU for Lima VM operations
+        sudo apt-get update
+        sudo apt-get install --yes qemu-system-x86 qemu-utils
+
+        # Set up run-in-shell helper script (as a symlink to bash)
+        mkdir -p bin
+        ln -s $(which bash) bin/run-in-shell
+        readlink -f bin >> "$GITHUB_PATH"
+
+        # Install a newer version of jq
+        wget --output-document=bin/jq https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64
+        chmod a+x bin/jq
+
+    - name: "macOS: Install prerequisites"
+      if: runner.os == 'macOS'
+      working-directory: ${{ runner.temp }}
+      run: |
+        brew install bash coreutils make docker
+
+        # Disable Spotlight indexing on all volumes. On macos-15-intel CI
+        # runners, mds/mds_stores/mdworker_shared collectively consumed
+        # ~230% CPU during BATS runs — more than two of the runner's four
+        # logical cores — starving Lima's VM of the cycles it needs to
+        # boot within the test timeout.
+        sudo mdutil -a -i off
+
+        # Set up run-in-shell helper script (as a symlink to bash)
+        mkdir -p bin
+        ln -s $(brew --prefix bash)/bin/bash bin/run-in-shell
+        readlink -f bin >> "$GITHUB_PATH"
+
+        # Use GNU make
+        echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+
+    - name: "Windows: install prerequisites"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      working-directory: ${{ runner.temp }}
+      run: |
+        # Stop unwanted services
+        Get-Service -ErrorAction Continue -Name @('W3SVC', 'docker') |
+          Stop-Service
+
+        # Update any pre-installed WSL
+        # Sometimes this fails; retry in a loop.
+        do { wsl --update } while ( -not $? )
+        # Setting the default version also lets WSL finish updating.
+        wsl --set-default-version 2
+
+        # Install MSYS2 packages for BATS.
+        # openssh is required because Lima constructs SSH paths using cygpath
+        # (/c/Users/...) which only MSYS2's ssh understands; Windows OpenSSH
+        # needs native paths and fails with "No such file or directory".
+        C:\msys64\usr\bin\pacman.exe --noconfirm --sync gzip jq make openbsd-netcat openssh
+
+        # Set up MSYS2 wrapper script
+        New-Item -ItemType Directory -Name bin -Force
+        Get-ItemPropertyValue -Path bin -Name FullName |
+          Out-File -Encoding UTF8 -Append "$env:GITHUB_PATH"
+
+        # Install yq
+        Invoke-WebRequest `
+          -Uri 'https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe' `
+          -OutFile bin/yq.exe
+
+        # Set up git configuration
+        git config --global --replace-all core.autocrlf false # spellchecker:ignore
+        git config --global --replace-all core.eol lf # spellchecker:ignore
+        git config --global --replace-all core.longpaths true # spellchecker:ignore
+
+    - name: "Windows: write MSYS2 wrapper script"
+      if: runner.os == 'Windows'
+      shell: cmd /c copy {0} run-in-shell.cmd
+      working-directory: ${{ runner.temp }}/bin
+      run: |
+        SET MSYSTEM=UCRT64
+        SET CHERE_INVOKING=1
+        SET MSYS2_PATH_TYPE=inherit
+        C:\msys64\usr\bin\bash.exe --login -e %1
+        EXIT %ERRORLEVEL%
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: rancher-sandbox/rancher-desktop-2
+        persist-credentials: false
+        submodules: recursive
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: rdd/go.mod
+        cache-dependency-path: rdd/go.sum
+
+    - run: >-
+        go env --json |
+        jq --raw-output 'to_entries | map(.key + "=" + .value) | .[]'
+        >> "$GITHUB_ENV"
+      shell: bash
+    - name: "Download image"
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+        name: distro-${{ matrix.type }}.xz-${{ env.GOARCH }}
+    - name: "Update image manifest"
+      shell: run-in-shell {0}
+      run: |
+        # Update the relevant image manifest, depending on the runner's OS.
+        set -o errexit -o nounset -o pipefail -o xtrace
+
+        ls -l
+        ls -l distro* || true
+        # macOS readlink doesn't support long options.
+        distro=$(readlink -f -n "distro.${{ matrix.type }}.xz")
+        checksum=$(sha256sum "${distro}" | awk '{print $1}')
+        manifest=lima-images-unix.yaml
+
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          distro=$(cygpath -m "${distro}")
+          manifest=lima-images-wsl2.yaml
+        fi
+
+        yq --inplace \
+          ".images[].location = \"file://${distro}\" | .images[].digest = \"sha256:${checksum}\" " \
+          "rdd/pkg/controllers/app/app/${manifest}"
+
+        git diff
+    - name: "Windows: disable Compatibility Telemetry"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/disable-compat-telemetry
+
+    - name: "Windows: WSL debugging"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        wsl --list --verbose
+        wsl --status
+      continue-on-error: true
+
+    - name: "Windows: capture machine info"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/windows-machine-info
+      with:
+        output-path: rdd/rdd-logs/_diag/machine-info.txt
+      continue-on-error: true
+
+    - name: "Windows: start typeperf sampler"
+      if: runner.os == 'Windows'
+      uses: ./.github/actions/windows-typeperf-sampler
+      with:
+        command: start
+        output-dir: rdd/rdd-logs/_diag
+      continue-on-error: true
+
+    - name: "Linux: size the app VM for the runner"
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        # The ubuntu runners also have 4 cores, and the host side idles at
+        # the 2-vCPU default; give the QEMU guest 3 and keep one core for
+        # the runner agent.
+        echo "RDD_VM_CPUS=3" >> "$GITHUB_ENV"
+
+    - name: "macOS: size the app VM for the runner"
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        # The 2-vCPU default starves the guest on the 4-core macos-15-intel
+        # runners: both vCPUs saturate during the k3s bootstrap and container
+        # creates take minutes. Give the VM all 4 cores: validation showed
+        # 4 vCPUs reaching pod-Running 2-3x faster than 3 and passing even
+        # the slowest runners, while the runner agent stayed scheduled
+        # through 0%-idle stretches. Drop to 3 if runs start losing their
+        # runner connection.
+        echo "RDD_VM_CPUS=4" >> "$GITHUB_ENV"
+
+    - name: Configure BATS targets
+      shell: bash
+      run: |
+        case "${{ matrix.suite }}" in
+          bats-app|bats-lima)
+            echo "BATS_TARGET=${{ matrix.suite }}" >> "$GITHUB_ENV"
+            ;;
+          bats-others)
+            echo "BATS_EXCLUDES=bats-app bats-lima" >> "$GITHUB_ENV"
+            echo "BATS_TARGET=bats-all" >> "$GITHUB_ENV"
+            ;;
+          *)
+            echo "Unknown test suite: ${{ matrix.suite }}" >&2
+            exit 1
+            ;;
+        esac
+
+    - run: make -C bats ${{ env.BATS_TARGET }} --keep-going
+      working-directory: rdd
+      shell: run-in-shell {0}
+      env:
+        RDD_TRACE: true
+        RDD_LOG_LEVEL: trace
+
+    - name: "Windows: stop typeperf sampler"
+      if: always() && runner.os == 'Windows'
+      uses: ./.github/actions/windows-typeperf-sampler
+      with:
+        command: stop
+        output-dir: rdd/rdd-logs/_diag
+      continue-on-error: true
+
+    - name: Collect RDD logs
+      if: always()
+      shell: run-in-shell {0}
+      working-directory: rdd
+      run: scripts/collect-bats-logs.sh rdd-logs
+
+    - name: Upload RDD service logs
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: rdd-logs-${{ matrix.runs-on }}-${{ matrix.suite }}
+        path: rdd/rdd-logs/
+        if-no-files-found: ignore


### PR DESCRIPTION
This is a bit wasteful (because the PR in rancher-desktop-2 will run BATS before being merged), but it gives us higher confidence that any pull requests will not break BATS.