### PR TITLE
Replace vsock port literals with named constants

### DIFF
--- a/src/go/networking/cmd/host/switch_windows.go
+++ b/src/go/networking/cmd/host/switch_windows.go
@@ -52,8 +52,8 @@ func main() {
 		fmt.Sprintf("Subnet range with CIDR suffix for virtual network, e,g: %s", config.DefaultSubnet))
 	flag.Var(&staticPortForward, "port-forward",
 		"List of ports that needs to be pre forwarded to the WSL VM in Host:Port=Guest:Port format e.g: 127.0.0.1:2222=192.168.127.2:22")
-	flag.IntVar(&vsockHandshakePort, "vsock-handshake-port", 6670, "port for vsock handshake")
-	flag.IntVar(&vsockListenPort, "vsock-listen-port", 6657, "port for vsock to listen on for connections from the VM")
+	flag.IntVar(&vsockHandshakePort, "vsock-handshake-port", vsock.DefaultHandshakePort, "port for vsock handshake")
+	flag.IntVar(&vsockListenPort, "vsock-listen-port", vsock.DefaultListenPort, "port for vsock to listen on for connections from the VM")
 	flag.Parse()
 
 	if debug {

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -219,8 +219,8 @@ func initializeFlags() {
 	flag.BoolVar(&options.vmSwitchLogFileAppend, "vm-switch-logfile-append", false, "append to the vm-switch logfile instead of truncating it on start")
 	flag.StringVar(&options.unshareArg, "unshare-arg", "", "the command argument to pass to the unshare program")
 	flag.StringVar(&options.logFile, "logfile", "/var/log/network-setup.log", "path to the logfile for network setup process")
-	flag.IntVar(&options.vsockHandshakePort, "vsock-handshake-port", 6670, "port for vsock handshake")
-	flag.IntVar(&options.vsockDialPort, "vsock-dial-port", 6657, "host switch port for vsock dial")
+	flag.IntVar(&options.vsockHandshakePort, "vsock-handshake-port", rdvsock.DefaultHandshakePort, "port for vsock handshake")
+	flag.IntVar(&options.vsockDialPort, "vsock-dial-port", rdvsock.DefaultListenPort, "host switch port for vsock dial")
 	flag.Parse()
 }
 

--- a/src/go/networking/pkg/vsock/constants.go
+++ b/src/go/networking/pkg/vsock/constants.go
@@ -19,3 +19,10 @@ const (
 	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop-opensuse/src/go/networking"
 	ReadySignal     = "READY"
 )
+
+// Default vsock ports for communication between host and VM. The VM dials the
+// host switch's listen port; both sides use the same handshake port.
+const (
+	DefaultHandshakePort = 6670
+	DefaultListenPort    = 6657
+)


### PR DESCRIPTION
The mnd linter flags the 6670 and 6657 vsock port literals as magic numbers. Define them once in pkg/vsock as DefaultHandshakePort and DefaultListenPort so the host and VM sides share one definition of the ports they must agree on.

This unblocks the Lint check on the open dependabot PRs (#59–#62), which fail on these literals inherited from main.

They slipped in because #56 ran lint, then #57 was merged, and #56 was merged after without running lint again.
